### PR TITLE
Make code coverage work on Gradle 8.7

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -13,6 +13,14 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     }
 }
 
+sourceSets {
+    main {
+        kotlin {
+            srcDir(layout.projectDirectory.dir("../shared-build-logic/src/main/kotlin"))
+        }
+    }
+}
+
 java {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11

--- a/common/src/main/kotlin/com/toasttab/gradle/testkit/Constants.kt
+++ b/common/src/main/kotlin/com/toasttab/gradle/testkit/Constants.kt
@@ -1,4 +1,0 @@
-package com.toasttab.gradle.testkit
-
-const val TESTKIT_COVERAGE_OUTPUT = "testkit-coverage-output"
-const val TESTKIT_PROJECTS = "testkit-projects"

--- a/coverage-plugin/build.gradle.kts
+++ b/coverage-plugin/build.gradle.kts
@@ -1,3 +1,7 @@
+import com.toasttab.gradle.testkit.shared.configureInstrumentation
+import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier
+import org.gradle.jvm.tasks.Jar
+
 plugins {
     `kotlin-conventions`
     `plugin-publishing-conventions`
@@ -6,7 +10,6 @@ plugins {
 
 dependencies {
     implementation(gradleApi())
-    implementation(projects.common)
     implementation(projects.jacocoReflect)
 
     testImplementation(projects.junit5)
@@ -15,13 +18,7 @@ dependencies {
     testImplementation(libs.jacoco.core)
 }
 
-tasks {
-    test {
-        systemProperty("javaagent", project.zipTree(project.configurations.getByName("jacocoAgent").asPath).filter {
-            it.name == "jacocoagent.jar"
-        }.singleFile.path)
-    }
-}
+configureInstrumentation()
 
 gradlePlugin {
     plugins {

--- a/coverage-plugin/src/main/kotlin/com/toasttab/gradle/testkit/FlushJacocoPlugin.kt
+++ b/coverage-plugin/src/main/kotlin/com/toasttab/gradle/testkit/FlushJacocoPlugin.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2024 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.toasttab.gradle.testkit
 
 import com.toasttab.gradle.testkit.jacoco.JacocoRt
@@ -10,7 +25,7 @@ class FlushJacocoPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         target.gradle.addBuildListener(object : BuildAdapter() {
             override fun buildFinished(result: BuildResult) {
-                JacocoRt.agent!!.dump(false)
+                JacocoRt.requiredAgent.dump(false)
             }
         })
     }

--- a/coverage-plugin/src/main/kotlin/com/toasttab/gradle/testkit/FlushJacocoPlugin.kt
+++ b/coverage-plugin/src/main/kotlin/com/toasttab/gradle/testkit/FlushJacocoPlugin.kt
@@ -16,17 +16,23 @@
 package com.toasttab.gradle.testkit
 
 import com.toasttab.gradle.testkit.jacoco.JacocoRt
-import org.gradle.BuildAdapter
-import org.gradle.BuildResult
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.flow.FlowAction
+import org.gradle.api.flow.FlowParameters
+import org.gradle.api.flow.FlowScope
+import javax.inject.Inject
 
-class FlushJacocoPlugin : Plugin<Project> {
+class FlushJacocoPlugin @Inject constructor(
+    private val flowScope: FlowScope
+) : Plugin<Project> {
     override fun apply(target: Project) {
-        target.gradle.addBuildListener(object : BuildAdapter() {
-            override fun buildFinished(result: BuildResult) {
-                JacocoRt.requiredAgent.dump(false)
-            }
-        })
+        flowScope.always(DumpAction::class.java) { }
+    }
+}
+
+class DumpAction : FlowAction<FlowParameters.None> {
+    override fun execute(parameters: FlowParameters.None) {
+        JacocoRt.requiredAgent.dump(false)
     }
 }

--- a/coverage-plugin/src/test/kotlin/com/toasttab/gradle/testkit/FlushJacocoPluginIntegrationTest.kt
+++ b/coverage-plugin/src/test/kotlin/com/toasttab/gradle/testkit/FlushJacocoPluginIntegrationTest.kt
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.io.TempDir
 import strikt.api.expectThat
 import strikt.assertions.contains
 import java.nio.file.Path
+import kotlin.io.path.Path
 import kotlin.io.path.inputStream
 import kotlin.io.path.writeText
 
@@ -32,11 +33,10 @@ class FlushJacocoPluginIntegrationTest {
 
     @Test
     fun `coverage is flushed`() {
-        val javaagent = System.getProperty("javaagent")
         val file = dir.resolve("build/testkit.exec")
 
         dir.resolve("gradle.properties").writeText(
-            "org.gradle.jvmargs=-javaagent:$javaagent=destfile=$file"
+            "systemProp.jacoco-agent.destfile=$file"
         )
 
         dir.resolve("build.gradle.kts").writeText(
@@ -49,9 +49,12 @@ class FlushJacocoPluginIntegrationTest {
         )
 
         GradleRunner.create()
-            .withGradleVersion("8.6")
+            .withGradleVersion("8.7")
             .withProjectDir(dir.toFile())
-            .withPluginClasspath().withArguments("build").build()
+            .withPluginClasspath(
+                TestProjectExtension.pluginClasspath()
+            )
+            .withArguments("build", "--stacktrace").build()
 
         val classes = hashSetOf<String>()
 

--- a/coverage-plugin/src/test/kotlin/com/toasttab/gradle/testkit/FlushJacocoPluginIntegrationTest.kt
+++ b/coverage-plugin/src/test/kotlin/com/toasttab/gradle/testkit/FlushJacocoPluginIntegrationTest.kt
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.io.TempDir
 import strikt.api.expectThat
 import strikt.assertions.contains
 import java.nio.file.Path
-import kotlin.io.path.Path
 import kotlin.io.path.inputStream
 import kotlin.io.path.writeText
 
@@ -52,7 +51,7 @@ class FlushJacocoPluginIntegrationTest {
             .withGradleVersion("8.7")
             .withProjectDir(dir.toFile())
             .let(TestProjectExtension.pluginClasspath()::apply)
-            .withArguments("build")
+            .withArguments("build", "--configuration-cache")
             .build()
 
         val classes = hashSetOf<String>()

--- a/coverage-plugin/src/test/kotlin/com/toasttab/gradle/testkit/FlushJacocoPluginIntegrationTest.kt
+++ b/coverage-plugin/src/test/kotlin/com/toasttab/gradle/testkit/FlushJacocoPluginIntegrationTest.kt
@@ -52,7 +52,7 @@ class FlushJacocoPluginIntegrationTest {
             .withGradleVersion("8.7")
             .withProjectDir(dir.toFile())
             .let(TestProjectExtension.pluginClasspath()::apply)
-            .withArguments("build", "--stacktrace").build()
+            .withArguments("build")
 
         val classes = hashSetOf<String>()
 

--- a/coverage-plugin/src/test/kotlin/com/toasttab/gradle/testkit/FlushJacocoPluginIntegrationTest.kt
+++ b/coverage-plugin/src/test/kotlin/com/toasttab/gradle/testkit/FlushJacocoPluginIntegrationTest.kt
@@ -51,9 +51,7 @@ class FlushJacocoPluginIntegrationTest {
         GradleRunner.create()
             .withGradleVersion("8.7")
             .withProjectDir(dir.toFile())
-            .withPluginClasspath(
-                TestProjectExtension.pluginClasspath()
-            )
+            .let(TestProjectExtension.pluginClasspath()::apply)
             .withArguments("build", "--stacktrace").build()
 
         val classes = hashSetOf<String>()

--- a/coverage-plugin/src/test/kotlin/com/toasttab/gradle/testkit/FlushJacocoPluginIntegrationTest.kt
+++ b/coverage-plugin/src/test/kotlin/com/toasttab/gradle/testkit/FlushJacocoPluginIntegrationTest.kt
@@ -53,6 +53,7 @@ class FlushJacocoPluginIntegrationTest {
             .withProjectDir(dir.toFile())
             .let(TestProjectExtension.pluginClasspath()::apply)
             .withArguments("build")
+            .build()
 
         val classes = hashSetOf<String>()
 

--- a/jacoco-reflect/build.gradle.kts
+++ b/jacoco-reflect/build.gradle.kts
@@ -14,8 +14,6 @@ tasks {
 }
 
 dependencies {
-    implementation(projects.common)
-
     testImplementation(projects.junit5)
     testImplementation(libs.junit)
     testImplementation(libs.strikt.core)

--- a/jacoco-reflect/src/test/kotlin/com/toasttab/gradle/testkit/jacoco/JacocoRtTest.kt
+++ b/jacoco-reflect/src/test/kotlin/com/toasttab/gradle/testkit/jacoco/JacocoRtTest.kt
@@ -17,18 +17,10 @@ package com.toasttab.gradle.testkit.jacoco
 
 import org.junit.jupiter.api.Test
 import strikt.api.expectThat
-import strikt.assertions.endsWith
 import strikt.assertions.isEqualTo
 import strikt.assertions.isNotNull
 
 class JacocoRtTest {
-    @Test
-    fun `jacoco agent location is sane`() {
-        expectThat(JacocoRt.agent).isNotNull().and {
-            get { location }.endsWith("agent.jar")
-        }
-    }
-
     @Test
     fun `jacoco includes are correct`() {
         expectThat(JacocoRt.agent).isNotNull().and {

--- a/junit5/build.gradle.kts
+++ b/junit5/build.gradle.kts
@@ -14,7 +14,6 @@ tasks {
 }
 
 dependencies {
-    implementation(projects.common)
     implementation(projects.jacocoReflect)
     implementation(libs.junit)
     implementation(gradleTestKit())

--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProject.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProject.kt
@@ -17,7 +17,6 @@ package com.toasttab.gradle.testkit
 
 import org.gradle.testkit.runner.GradleRunner
 import org.slf4j.LoggerFactory
-import java.io.File
 import java.io.StringWriter
 import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicBoolean
@@ -27,13 +26,13 @@ import kotlin.io.path.deleteRecursively
 sealed interface PluginClasspath {
     fun apply(runner: GradleRunner): GradleRunner
 
-    object Default: PluginClasspath {
+    object Default : PluginClasspath {
         override fun apply(runner: GradleRunner) = runner.withPluginClasspath()
     }
 
     class Custom(
         private val paths: List<Path>
-    ): PluginClasspath {
+    ) : PluginClasspath {
 
         init {
             println("PATHS = $paths")

--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProject.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProject.kt
@@ -33,10 +33,6 @@ sealed interface PluginClasspath {
     class Custom(
         private val paths: List<Path>
     ) : PluginClasspath {
-
-        init {
-            println("PATHS = $paths")
-        }
         override fun apply(runner: GradleRunner) = runner.withPluginClasspath(paths.map(Path::toFile))
     }
 }

--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProject.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProject.kt
@@ -17,6 +17,7 @@ package com.toasttab.gradle.testkit
 
 import org.gradle.testkit.runner.GradleRunner
 import org.slf4j.LoggerFactory
+import java.io.File
 import java.io.StringWriter
 import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicBoolean
@@ -25,6 +26,7 @@ import kotlin.io.path.deleteRecursively
 
 class TestProject(
     val dir: Path,
+    private val classpath: List<File>,
     private val gradleVersion: GradleVersionArgument,
     private val cleanup: Boolean,
 ) {
@@ -43,8 +45,13 @@ class TestProject(
         }
     }
 
-    fun createRunner() = createRunnerWithoutPluginClasspath()
-        .withPluginClasspath()
+    fun createRunner() = createRunnerWithoutPluginClasspath().apply {
+        if (classpath.isEmpty()) {
+            withPluginClasspath()
+        } else {
+            withPluginClasspath(classpath)
+        }
+    }
 
     fun createRunnerWithoutPluginClasspath() = GradleRunner.create()
         .withProjectDir(dir.toFile())

--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProjectExtension.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProjectExtension.kt
@@ -143,7 +143,6 @@ class TestProjectExtension : ParameterResolver, BeforeAllCallback, AfterTestExec
                             """
                             
                             # custom jacoco properties
-                            
                             systemProp.jacoco-agent.output=tcpclient
                             systemProp.jacoco-agent.port=${collector.port}
                             systemProp.jacoco-agent.sessionid=test

--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProjectExtension.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProjectExtension.kt
@@ -139,7 +139,8 @@ class TestProjectExtension : ParameterResolver, BeforeAllCallback, AfterTestExec
                             createFile()
                         }
 
-                        appendText("""
+                        appendText(
+                            """
                             
                             # custom jacoco properties
                             
@@ -148,7 +149,8 @@ class TestProjectExtension : ParameterResolver, BeforeAllCallback, AfterTestExec
                             systemProp.jacoco-agent.sessionid=test
                             systemProp.jacoco-agent.includes=${coverage.includes}
                             systemProp.jacoco-agent.excludes=${coverage.excludes}
-                        """.trimIndent())
+                            """.trimIndent()
+                        )
                     }
                 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,5 +14,5 @@ rootProject.name = "testkit-plugins"
 apply(plugin = "net.vivin.gradle-semantic-build-versioning")
 
 include(
-    ":jacoco-reflect", ":junit5", ":common", ":testkit-plugin", ":coverage-plugin"
+    ":jacoco-reflect", ":junit5", ":testkit-plugin", ":coverage-plugin"
 )

--- a/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/Artifacts.kt
+++ b/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/Artifacts.kt
@@ -20,10 +20,11 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.artifacts.result.ArtifactResult
 import org.gradle.api.attributes.Attribute
+import org.gradle.api.plugins.JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME
 
 private val ARTIFACT_TYPE_ATTRIBUTE = Attribute.of("artifactType", String::class.java)
 
-fun Project.runtimeArtifacts() = configurations.getAt("runtimeClasspath").incoming.artifactView {
+fun Project.runtimeArtifacts() = configurations.getAt(RUNTIME_CLASSPATH_CONFIGURATION_NAME).incoming.artifactView {
     lenient(true)
     attributes.attribute(ARTIFACT_TYPE_ATTRIBUTE, "jar")
 }.artifacts

--- a/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/Artifacts.kt
+++ b/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/Artifacts.kt
@@ -16,13 +16,22 @@
 package com.toasttab.gradle.testkit.shared
 
 import org.gradle.api.Project
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.artifacts.result.ArtifactResult
 import org.gradle.api.attributes.Attribute
 
+private val ARTIFACT_TYPE_ATTRIBUTE = Attribute.of("artifactType", String::class.java)
+
 fun Project.runtimeArtifacts() = configurations.getAt("runtimeClasspath").incoming.artifactView {
     lenient(true)
-    attributes.attribute(Attribute.of("artifactType", String::class.java), "jar")
+    attributes.attribute(ARTIFACT_TYPE_ATTRIBUTE, "jar")
 }.artifacts
 
 fun ArtifactResult.isProject() = id.componentIdentifier is ProjectComponentIdentifier
+
+fun ArtifactResult.isExternalPluginDependency(): Boolean {
+    val identifier = id.componentIdentifier
+
+    return identifier is ModuleComponentIdentifier && identifier.group != "org.jetbrains.kotlin"
+}

--- a/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/Artifacts.kt
+++ b/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/Artifacts.kt
@@ -13,20 +13,16 @@
  * limitations under the License.
  */
 
-package com.toasttab.gradle.testkit
+package com.toasttab.gradle.testkit.shared
 
-import com.toasttab.gradle.testkit.jacoco.JacocoRt
+import org.gradle.api.Project
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier
+import org.gradle.api.artifacts.result.ArtifactResult
+import org.gradle.api.attributes.Attribute
 
-class CoverageSettings(
-    val includes: String,
-    val excludes: String,
-    val output: String
-) {
-    companion object {
-        val settings by lazy {
-            JacocoRt.agent?.let {
-                CoverageSettings(it.includes, it.excludes, System.getProperty("testkit-coverage-output"))
-            }
-        }
-    }
-}
+fun Project.runtimeArtifacts() = configurations.getAt("runtimeClasspath").incoming.artifactView {
+    lenient(true)
+    attributes.attribute(Attribute.of("artifactType", String::class.java), "jar")
+}.artifacts
+
+fun ArtifactResult.isProject() = id.componentIdentifier is ProjectComponentIdentifier

--- a/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/CopyLocalJars.kt
+++ b/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/CopyLocalJars.kt
@@ -44,7 +44,7 @@ abstract class CopyLocalJars : DefaultTask() {
 
     @TaskAction
     fun copy() {
-        project.copy {
+        project.sync {
             from(artifacts.filter(ArtifactResult::isProject).map {
                 it.file
             })

--- a/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/CopyLocalJars.kt
+++ b/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/CopyLocalJars.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.gradle.testkit.shared
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.artifacts.ArtifactCollection
+import org.gradle.api.artifacts.result.ArtifactResult
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.jvm.tasks.Jar
+
+abstract class CopyLocalJars : DefaultTask() {
+    @get:InputFiles
+    val artifactFiles get() = artifacts.artifactFiles
+
+    @Internal
+    lateinit var artifacts: ArtifactCollection
+
+    @Internal
+    lateinit var jar: TaskProvider<Jar>
+
+    @get:InputFile
+    val jarFile get() = jar.map { it.archiveFile }
+
+    @OutputDirectory
+    lateinit var dir: Any
+
+    @TaskAction
+    fun copy() {
+        project.copy {
+            from(artifacts.filter(ArtifactResult::isProject).map {
+                it.file
+            })
+
+            from(jar)
+
+            into(dir)
+        }
+    }
+}

--- a/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/CopyLocalJarsTask.kt
+++ b/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/CopyLocalJarsTask.kt
@@ -26,7 +26,7 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.jvm.tasks.Jar
 
-abstract class CopyLocalJars : DefaultTask() {
+abstract class CopyLocalJarsTask : DefaultTask() {
     @get:InputFiles
     val artifactFiles get() = artifacts.artifactFiles
 

--- a/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/InstrumentWithJacocoOffline.kt
+++ b/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/InstrumentWithJacocoOffline.kt
@@ -15,9 +15,12 @@
 
 package com.toasttab.gradle.testkit.shared
 
+import org.gradle.api.Action
 import org.gradle.api.DefaultTask
+import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.Directory
+import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFiles
@@ -37,6 +40,10 @@ abstract class InstrumentWithJacocoOffline : DefaultTask() {
 
     @TaskAction
     fun instrument() {
+        project.delete {
+            delete(dir)
+        }
+
         project.ant.withGroovyBuilder {
             "taskdef"(
                 "name" to "instrument",

--- a/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/InstrumentWithJacocoOffline.kt
+++ b/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/InstrumentWithJacocoOffline.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.gradle.testkit.shared
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.withGroovyBuilder
+
+abstract class InstrumentWithJacocoOffline : DefaultTask() {
+    @InputFiles
+    lateinit var classpath: Configuration
+
+    @InputDirectory
+    lateinit var jars: Provider<Directory>
+
+    @OutputDirectory
+    lateinit var dir: Provider<Directory>
+
+    @TaskAction
+    fun instrument() {
+        project.ant.withGroovyBuilder {
+            "taskdef"(
+                "name" to "instrument",
+                "classname" to "org.jacoco.ant.InstrumentTask",
+                "classpath" to classpath.asPath
+            )
+            "instrument"("destdir" to dir.get().asFile.path) {
+                "fileset"("dir" to jars.get().asFile.path)
+            }
+        }
+    }
+}

--- a/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/InstrumentWithJacocoOfflineTask.kt
+++ b/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/InstrumentWithJacocoOfflineTask.kt
@@ -15,12 +15,9 @@
 
 package com.toasttab.gradle.testkit.shared
 
-import org.gradle.api.Action
 import org.gradle.api.DefaultTask
-import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.Directory
-import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFiles
@@ -28,7 +25,7 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.withGroovyBuilder
 
-abstract class InstrumentWithJacocoOffline : DefaultTask() {
+abstract class InstrumentWithJacocoOfflineTask : DefaultTask() {
     @InputFiles
     lateinit var classpath: Configuration
 

--- a/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/OfflineInstrumentation.kt
+++ b/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/OfflineInstrumentation.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2024 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.gradle.testkit.shared
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.ArtifactCollection
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.testing.Test
+import org.gradle.jvm.tasks.Jar
+import org.gradle.kotlin.dsl.named
+import org.gradle.kotlin.dsl.register
+import java.io.File
+
+private fun Project.instrumentedDir() = layout.buildDirectory.dir("instrumented-local-jars")
+private fun Project.localJarsDir() = layout.buildDirectory.dir("local-jars")
+
+private fun Project.jacocoAgentRuntime() = zipTree(configurations.getAt("jacocoAgent").asPath).filter {
+    it.name == "jacocoagent.jar"
+}.singleFile
+
+private fun ArtifactCollection.externalPluginDependencies() = filter {
+    val identifier = it.id.componentIdentifier
+
+    identifier is ModuleComponentIdentifier && identifier.group != "org.jetbrains.kotlin"
+}
+
+fun Project.configureInstrumentation() {
+    pluginManager.withPlugin("jacoco") {
+        tasks.register<CopyLocalJars>("copyLocalJars") {
+            artifacts = runtimeArtifacts()
+
+            jar = tasks.named<Jar>("jar")
+
+            dir = localJarsDir()
+        }
+
+        tasks.register<InstrumentWithJacocoOffline>("instrumentLocalJars") {
+            dependsOn("copyLocalJars")
+
+            classpath = configurations.getAt("jacocoAnt")
+
+            jars = localJarsDir()
+            dir = instrumentedDir()
+        }
+
+        tasks.named<Test>("test") {
+            dependsOn("instrumentLocalJars")
+
+            val runtimeArtifacts = runtimeArtifacts()
+
+            inputs.files(runtimeArtifacts.artifactFiles).withPropertyName("plugin-artifacts").withPathSensitivity(
+                PathSensitivity.RELATIVE
+            )
+            inputs.dir(instrumentedDir())
+
+            systemProperty("testkit-plugin-instrumented-jars", instrumentedDir().get().asFile.path)
+            systemProperty("testkit-plugin-external-jars", runtimeArtifacts.externalPluginDependencies()
+                .joinToString(separator = File.pathSeparator) {
+                    it.file.path
+                })
+            systemProperty("testkit-plugin-jacoco-jar", jacocoAgentRuntime().path)
+        }
+    }
+}

--- a/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/OfflineInstrumentation.kt
+++ b/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/OfflineInstrumentation.kt
@@ -16,8 +16,6 @@
 package com.toasttab.gradle.testkit.shared
 
 import org.gradle.api.Project
-import org.gradle.api.artifacts.ArtifactCollection
-import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.result.ArtifactResult
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.PathSensitivity
@@ -40,7 +38,7 @@ private fun Project.jacocoAgentRuntime() = zipTree(configurations.getAt(JacocoPl
 
 fun Project.configureInstrumentation() {
     pluginManager.withPlugin("jacoco") {
-        tasks.register<CopyLocalJars>(COPY_LOCAL_JARS_TASK) {
+        tasks.register<CopyLocalJarsTask>(COPY_LOCAL_JARS_TASK) {
             artifacts = runtimeArtifacts()
 
             jar = tasks.named<Jar>(JavaPlugin.JAR_TASK_NAME)
@@ -48,7 +46,7 @@ fun Project.configureInstrumentation() {
             dir = localJarsDir()
         }
 
-        tasks.register<InstrumentWithJacocoOffline>(INSTRUMENT_LOCAL_JARS_TASK) {
+        tasks.register<InstrumentWithJacocoOfflineTask>(INSTRUMENT_LOCAL_JARS_TASK) {
             dependsOn(COPY_LOCAL_JARS_TASK)
 
             classpath = configurations.getAt(JacocoPlugin.ANT_CONFIGURATION_NAME)

--- a/testkit-plugin/build.gradle.kts
+++ b/testkit-plugin/build.gradle.kts
@@ -5,9 +5,16 @@ plugins {
 }
 
 dependencies {
-    implementation(projects.common)
     implementation(gradleApi())
     testImplementation(libs.strikt.core)
+}
+
+sourceSets {
+    main {
+        kotlin {
+            srcDir(rootProject.layout.projectDirectory.dir("shared-build-logic/src/main/kotlin"))
+        }
+    }
 }
 
 tasks {

--- a/testkit-plugin/src/main/kotlin/com/toasttab/gradle/testkit/JacocoOutputCleanupTestTaskAction.kt
+++ b/testkit-plugin/src/main/kotlin/com/toasttab/gradle/testkit/JacocoOutputCleanupTestTaskAction.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2024 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.toasttab.gradle.testkit
 
 import org.gradle.api.Action

--- a/testkit-plugin/src/main/kotlin/com/toasttab/gradle/testkit/TestkitExtension.kt
+++ b/testkit-plugin/src/main/kotlin/com/toasttab/gradle/testkit/TestkitExtension.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2024 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.toasttab.gradle.testkit
 
 open class TestkitExtension {

--- a/testkit-plugin/src/main/kotlin/com/toasttab/gradle/testkit/TestkitPlugin.kt
+++ b/testkit-plugin/src/main/kotlin/com/toasttab/gradle/testkit/TestkitPlugin.kt
@@ -1,5 +1,21 @@
+/*
+ * Copyright (c) 2024 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.toasttab.gradle.testkit
 
+import com.toasttab.gradle.testkit.shared.configureInstrumentation
 import org.apache.tools.ant.filters.ReplaceTokens
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -32,6 +48,8 @@ class TestkitPlugin @Inject constructor(
             }
         }
 
+        project.configureInstrumentation()
+
         project.tasks.named<Test>("test") {
             dependsOn("copyTestProjects")
 
@@ -41,10 +59,10 @@ class TestkitPlugin @Inject constructor(
 
             // declare an additional jacoco output file so that the JUnit JVM and the TestKit JVM
             // do not try to write to the same file
-            outputs.file(destfile).withPropertyName(TESTKIT_COVERAGE_OUTPUT)
+            outputs.file(destfile).withPropertyName("testkit-coverage-output")
 
-            systemProperty(TESTKIT_COVERAGE_OUTPUT, "${destfile.get()}")
-            systemProperty(TESTKIT_PROJECTS, "${testProjectDir.get()}")
+            systemProperty("testkit-coverage-output", "${destfile.get()}")
+            systemProperty("testkit-projects", "${testProjectDir.get()}")
         }
 
         project.pluginManager.withPlugin("jvm-test-suite") {

--- a/testkit-plugin/src/test/kotlin/com/toasttab/gradle/testkit/TestkitPluginIntegrationTest.kt
+++ b/testkit-plugin/src/test/kotlin/com/toasttab/gradle/testkit/TestkitPluginIntegrationTest.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2024 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.toasttab.gradle.testkit
 
 import org.gradle.testkit.runner.GradleRunner


### PR DESCRIPTION
Change from online to offline instrumentation to make code coverage work on Gradle 8.7.

Roughly, this works as follows:

* All subprojects of the root project, including the plugin subproject, that the plugin uses are packaged into jars and copied into a temporary build directory
* Jacoco offline instrumentation runs on these jars via Ant
* The locations of instrumented jars, the rest of plugin dependencies (excluding Gradle and Kotlin libraries which are bundled into Gradle), and the jacoco runtime are passed into tests via system properties
* The test extension reconstructs the plugin classpath from said system properties and passes it into TestKit
* Additionally, the test extension passes Jacoco options into the TestKit by injecting system properties into test projects' gradle.properties

This also improves compatibility with configuration cache by using `FlowScope` instead of `BuildListener` to listen to build completion. `FlowScope` is an incubating API and requires Gradle 8.1+.