### PR TITLE
Improve display names for tests

### DIFF
--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestKit.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestKit.kt
@@ -15,12 +15,14 @@
 
 package com.toasttab.gradle.testkit
 
+import org.junit.jupiter.api.DisplayNameGeneration
 import org.junit.jupiter.api.extension.ExtendWith
 import kotlin.reflect.KClass
 
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS)
 @ExtendWith(TestProjectExtension::class)
+@DisplayNameGeneration(TestKitDisplayNameGenerator::class)
 annotation class TestKit(
     val locator: KClass<out ProjectLocator> = SimpleNameProjectLocator::class,
     val gradleVersions: Array<String> = [],

--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestKitDisplayNameGenerator.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestKitDisplayNameGenerator.kt
@@ -15,14 +15,14 @@
 
 package com.toasttab.gradle.testkit
 
-class GradleVersionArgument private constructor(
-    val version: String?
-) {
-    override fun toString() = version ?: "default"
+import org.junit.jupiter.api.DisplayNameGenerator.Standard
+import java.lang.reflect.Method
 
-    companion object {
-        fun of(version: String) = GradleVersionArgument(version)
-
-        val DEFAULT = GradleVersionArgument(null)
-    }
+class TestKitDisplayNameGenerator : Standard() {
+    override fun generateDisplayNameForMethod(cls: Class<*>, method: Method) =
+        method.name + method.parameterTypes.filter {
+            it != TestProject::class.java
+        }.joinToString(", ", prefix = "(", postfix = ")") {
+            it.simpleName
+        }
 }

--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProject.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProject.kt
@@ -74,4 +74,6 @@ class TestProject(
             LOGGER.warn("build output:\n{}", output)
         }
     }
+
+    override fun toString() = "project(gradle: $gradleVersion)"
 }


### PR DESCRIPTION
* Strip `TestProject` parameter from display names of non-parameterized tests, it's implied
* Provide a reasonable `TestProject.toString` to be used by parameterized tests

```
TestKitIntegrationTest
    basic project
    basic parameterized project
         project(gradle: 8.6)
         project(gradle: 8.7)
```