### PR TITLE
Fix jacoco classloader issues when collecting coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ In the test project's `build.gradle.kts`, make sure to apply the coverage plugin
 
 ```
 plugins {
-    id("com.toasttab.testkit.coverage") version <<version>>
+    id("com.toasttab.testkit.coverage")
 }
 ```
 

--- a/coverage-plugin/build.gradle.kts
+++ b/coverage-plugin/build.gradle.kts
@@ -1,10 +1,5 @@
-import com.toasttab.gradle.testkit.shared.configureInstrumentation
-import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier
-import org.gradle.jvm.tasks.Jar
-
 plugins {
     `kotlin-conventions`
-    `plugin-publishing-conventions`
     jacoco
 }
 
@@ -17,19 +12,3 @@ dependencies {
     testImplementation(libs.strikt.core)
     testImplementation(libs.jacoco.core)
 }
-
-configureInstrumentation()
-
-gradlePlugin {
-    plugins {
-        create("jacoco") {
-            id = "com.toasttab.testkit.coverage"
-            implementationClass = "com.toasttab.gradle.testkit.FlushJacocoPlugin"
-            description = ProjectInfo.description
-            displayName = ProjectInfo.name
-            tags = listOf("jacoco", "testkit")
-        }
-    }
-}
-
-

--- a/coverage-plugin/src/main/resources/META-INF/gradle-plugins/com.toasttab.testkit.coverage.properties
+++ b/coverage-plugin/src/main/resources/META-INF/gradle-plugins/com.toasttab.testkit.coverage.properties
@@ -1,0 +1,1 @@
+implementation-class=com.toasttab.gradle.testkit.FlushJacocoPlugin

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,3 +26,4 @@ strikt-core = { module = "io.strikt:strikt-core", version.ref = "strikt" }
 
 [plugins]
 gradle-publish = { id = "com.gradle.plugin-publish", version = "1.2.0" }
+build-config = { id = "com.github.gmazzo.buildconfig", version = "5.3.5" }

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -1,0 +1,18 @@
+import com.toasttab.gradle.testkit.shared.configureInstrumentation
+
+plugins {
+    `kotlin-conventions`
+    jacoco
+}
+
+configureInstrumentation(projects.coveragePlugin)
+
+dependencies {
+    implementation(gradleApi())
+    testImplementation(libs.junit)
+    testImplementation(libs.strikt.core)
+    testImplementation(projects.jacocoReflect)
+    testImplementation(projects.junit5)
+    testImplementation(gradleTestKit())
+    testImplementation(libs.jacoco.core)
+}

--- a/integration-tests/src/main/kotlin/com/toasttab/gradle/testkit/TestPlugin.kt
+++ b/integration-tests/src/main/kotlin/com/toasttab/gradle/testkit/TestPlugin.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.gradle.testkit
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class TestPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+    }
+}

--- a/integration-tests/src/main/resources/META-INF/gradle-plugins/com.toasttab.testkit.test.properties
+++ b/integration-tests/src/main/resources/META-INF/gradle-plugins/com.toasttab.testkit.test.properties
@@ -1,0 +1,1 @@
+implementation-class=com.toasttab.gradle.testkit.TestPlugin

--- a/integration-tests/src/test/kotlin/com/toasttab/gradle/testkit/FlushJacocoPluginIntegrationTest.kt
+++ b/integration-tests/src/test/kotlin/com/toasttab/gradle/testkit/FlushJacocoPluginIntegrationTest.kt
@@ -15,7 +15,6 @@
 
 package com.toasttab.gradle.testkit
 
-import com.toasttab.gradle.testkit.jacoco.JacocoRt
 import org.gradle.testkit.runner.GradleRunner
 import org.jacoco.core.data.ExecutionDataReader
 import org.junit.jupiter.api.Test
@@ -43,6 +42,7 @@ class FlushJacocoPluginIntegrationTest {
                 plugins {
                     java
                     id("com.toasttab.testkit.coverage")
+                    id("com.toasttab.testkit.test")
                 }
             """.trimIndent()
         )
@@ -68,6 +68,6 @@ class FlushJacocoPluginIntegrationTest {
             }.read()
         }
 
-        expectThat(classes).contains(JacocoRt::class.java.name.replace('.', '/'))
+        expectThat(classes).contains(TestPlugin::class.java.name.replace('.', '/'))
     }
 }

--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProjectExtension.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProjectExtension.kt
@@ -164,6 +164,7 @@ class TestProjectExtension : ParameterResolver, BeforeAllCallback, AfterTestExec
                 val classpath = Path(instrumentedProperty).listDirectoryEntries().toMutableList()
 
                 System.getProperty("testkit-plugin-external-jars").split(File.pathSeparatorChar).mapTo(classpath, ::Path)
+                System.getProperty("testkit-coverage-jars").split(File.pathSeparatorChar).mapTo(classpath, ::Path)
                 classpath.add(Path(System.getProperty("testkit-plugin-jacoco-jar")))
 
                 PluginClasspath.Custom(classpath)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,5 +14,5 @@ rootProject.name = "testkit-plugins"
 apply(plugin = "net.vivin.gradle-semantic-build-versioning")
 
 include(
-    ":jacoco-reflect", ":junit5", ":testkit-plugin", ":coverage-plugin"
+    ":jacoco-reflect", ":junit5", ":testkit-plugin", ":coverage-plugin", ":integration-tests"
 )

--- a/testkit-plugin/build.gradle.kts
+++ b/testkit-plugin/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     `kotlin-conventions`
     `kotlin-dsl`
     `plugin-publishing-conventions`
+    alias(libs.plugins.build.config)
 }
 
 dependencies {
@@ -15,6 +16,11 @@ sourceSets {
             srcDir(rootProject.layout.projectDirectory.dir("shared-build-logic/src/main/kotlin"))
         }
     }
+}
+
+buildConfig {
+    packageName.set("com.toasttab.gradle.testkit")
+    buildConfigField("String", "VERSION", "\"$version\"")
 }
 
 tasks {

--- a/testkit-plugin/src/test/test-projects/TestkitPluginIntegrationTest/filtering/build.gradle.kts
+++ b/testkit-plugin/src/test/test-projects/TestkitPluginIntegrationTest/filtering/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     java
-    jacoco
     id("com.toasttab.testkit")
 }
 


### PR DESCRIPTION
In some cases, when the jacoco runtime is provided via TestKit's withPluginClasspath, the jacoco agent class ends up in a separate classloader from the coverage plugin.

We ensure that the coverage plugin is in the same classloader as the jacoco runtime by passing the coverage plugin jar into the TestKit's plugin classpath instead of letting the TestKit build resolve it normally. As a minor side effect, the coverage plugin version no longer needs to be explicitly specified, and the coverage plugin no longer needs to be published to the gradle plugin portal.