### PR TITLE
Allow custom jacoco version

### DIFF
--- a/coverage-plugin/build.gradle.kts
+++ b/coverage-plugin/build.gradle.kts
@@ -18,12 +18,6 @@ gradlePlugin {
 
 dependencies {
     implementation(gradleApi())
-    implementation(libs.jacoco.agent) {
-        artifact {
-            classifier = "runtime"
-            extension = "jar"
-        }
-    }
     implementation(projects.jacocoReflect)
 
     testImplementation(projects.junit5)

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.gradle.publish.PublishPlugin
+import com.gradle.publish.PublishTask
 import com.toasttab.gradle.testkit.shared.RepositoryDescriptor
 import com.toasttab.gradle.testkit.shared.configureIntegrationPublishing
 import com.toasttab.gradle.testkit.shared.publishOnlyIf
@@ -22,6 +24,10 @@ gradlePlugin {
     }
 }
 
+jacoco {
+    toolVersion = "0.8.12"
+}
+
 tasks {
     test {
         systemProperty("version", "$version")
@@ -31,6 +37,10 @@ tasks {
 
 configureIntegrationPublishing("testRuntimeClasspath")
 publishOnlyIf { _, repo -> repo == RepositoryDescriptor.INTEGRATION }
+
+tasks.withType<PublishTask> {
+    enabled = false
+}
 
 dependencies {
     implementation(gradleApi())

--- a/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/Artifacts.kt
+++ b/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/Artifacts.kt
@@ -15,24 +15,12 @@
 
 package com.toasttab.gradle.testkit.shared
 
-import org.gradle.api.Project
-import org.gradle.api.artifacts.component.ModuleComponentIdentifier
-import org.gradle.api.artifacts.component.ProjectComponentIdentifier
-import org.gradle.api.artifacts.result.ArtifactResult
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.attributes.Attribute
-import org.gradle.api.plugins.JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME
 
 private val ARTIFACT_TYPE_ATTRIBUTE = Attribute.of("artifactType", String::class.java)
 
-fun Project.runtimeArtifacts() = configurations.getAt(RUNTIME_CLASSPATH_CONFIGURATION_NAME).incoming.artifactView {
+fun Configuration.artifacts() = incoming.artifactView {
     lenient(true)
     attributes.attribute(ARTIFACT_TYPE_ATTRIBUTE, "jar")
 }.artifacts
-
-fun ArtifactResult.isProject() = id.componentIdentifier is ProjectComponentIdentifier
-
-fun ArtifactResult.isExternalPluginDependency(): Boolean {
-    val identifier = id.componentIdentifier
-
-    return identifier is ModuleComponentIdentifier && identifier.group != "org.jetbrains.kotlin"
-}

--- a/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/Jacoco.kt
+++ b/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/Jacoco.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.gradle.testkit.shared
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.testing.jacoco.plugins.JacocoPlugin
+
+sealed interface CoverageConfiguration {
+    object None: CoverageConfiguration
+
+    class Jacoco(
+        val configuration: Configuration
+    ): CoverageConfiguration {
+        val version by lazy {
+            configuration.artifacts().map { it.id.componentIdentifier }
+                .filterIsInstance<ModuleComponentIdentifier>()
+                .first { it.group == "org.jacoco" && it.module == "org.jacoco.ant" }
+                .version
+        }
+    }
+}
+
+fun Project.coverage() = configurations.findByName(JacocoPlugin.ANT_CONFIGURATION_NAME)?.let {
+    CoverageConfiguration.Jacoco(it)
+} ?: CoverageConfiguration.None

--- a/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/Pom.kt
+++ b/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/Pom.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.gradle.testkit.shared
+
+import groovy.namespace.QName
+import groovy.util.Node
+import org.gradle.api.publish.maven.MavenPom
+
+fun MavenPom.injectDependency(groupId: String, artifactId: String, version: String, classifier: String) {
+    withXml {
+        asNode().findOrCreateChild("dependencies").appendNode("dependency").apply {
+            appendNode("groupId", groupId)
+            appendNode("artifactId", artifactId)
+            appendNode("version", version)
+            appendNode("classifier", classifier)
+        }
+    }
+}
+
+private fun Node.findChild(localName: String) = children().filterIsInstance<Node>().firstOrNull { (it.name() as QName).localPart == localName }
+private fun Node.findOrCreateChild(localName: String) = findChild(localName) ?: appendNode(localName)


### PR DESCRIPTION
The version of the jacoco used to pre-instrument classes must match the version of jacoco used at runtime.

Instead of having the coverage plugin depend on the jacoco runtime, we inject the jacoco dependency (with the right version) when we publish a plugin under test into the integration repository