### PR TITLE
Fix a bug in filtering

### DIFF
--- a/testkit-plugin/src/main/kotlin/com/toasttab/gradle/testkit/TestkitPlugin.kt
+++ b/testkit-plugin/src/main/kotlin/com/toasttab/gradle/testkit/TestkitPlugin.kt
@@ -44,17 +44,15 @@ class TestkitPlugin @Inject constructor(
             from(extension.testProjectsDir)
             into(testProjectDir)
 
-            if (extension.replaceTokens.isNotEmpty()) {
-                filter<ReplaceTokens>(
-                    mapOf(
-                        "tokens" to mapOf(
-                            "TESTKIT_PLUGIN_VERSION" to BuildConfig.VERSION,
-                            "TESTKIT_INTEGRATION_REPO" to project.integrationRepo,
-                            "VERSION" to "${project.version}"
-                        ) + extension.replaceTokens
-                    )
+            filter<ReplaceTokens>(
+                mapOf(
+                    "tokens" to mapOf(
+                        "TESTKIT_PLUGIN_VERSION" to BuildConfig.VERSION,
+                        "TESTKIT_INTEGRATION_REPO" to project.integrationRepo,
+                        "VERSION" to "${project.version}"
+                    ) + extension.replaceTokens
                 )
-            }
+            )
         }
 
         project.tasks.named<Test>("test") {


### PR DESCRIPTION
`@VERSION` etc. will not be filtered in unless at least one custom replacement token is specified 