### PR TITLE
Misc cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,16 @@ dependencies {
 }
 ```
 
-Each test method is expected to have a corresponding test project located at `src/test/projects/<<Test>>/<<method>>`.
+Each test method is expected to have a corresponding test project located, by default, at `src/test/projects/<<Test>>/<<method>>`.
 
 ```shell
 src/test/projects/MyTest/sometest:
    build.gradle.kts
    settings.gradle.kts # optional, but IntelliJ will complain
 ```
+
+The location of the test project is can be customized by specifying a custom `ProjectLocator` implementation
+via the `@TestKit` annotation on the test class (e.g. `FullyQualifiedNameProjectLocator`).
 
 Test project files may contain Ant-style placeholders. The predefined placeholders are:
 
@@ -86,7 +89,7 @@ class ParameterizedTest {
 This plugin does not use the TestKit's plugin classpath injection mechanism because the mechanism breaks
 in certain scenarios, e.g. when plugins depend on other plugins. Instead, this plugin installs
 the plugin under test and its sibling dependencies, optionally preinstrumented for Jacoco code coverage,
-into an integration repository on disk, an technique borrowed from [DAGP](https://github.com/autonomousapps/dependency-analysis-gradle-plugin). 
+into an integration repository on disk, a technique borrowed from [DAGP](https://github.com/autonomousapps/dependency-analysis-gradle-plugin). 
 
 The integration repository is then injected into the plugin management repositories via a custom init
 script which is generated on the fly.
@@ -107,7 +110,7 @@ classes on the fly.
 * The jacoco plugin applied to the TestKit project ensures that the coverage is fully flushed after the test finishes. 
   This ensures that the coverage is recorded even though the TestKit process might still be lingering.
 
-See
+For more context, see
 
 * https://github.com/gradle/gradle/issues/1465
 * https://github.com/gradle/gradle/issues/12535

--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/ProjectLocator.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/ProjectLocator.kt
@@ -27,3 +27,8 @@ class SimpleNameProjectLocator : ProjectLocator {
     override fun projectPath(root: String, context: ExtensionContext) =
         Path(root, context.requiredTestClass.simpleName, context.requiredTestMethod.name)
 }
+
+class FullyQualifiedNameProjectLocator : ProjectLocator {
+    override fun projectPath(root: String, context: ExtensionContext) =
+        Path(root, context.requiredTestClass.name.replace('.', '/'), context.requiredTestMethod.name)
+}

--- a/junit5/src/test/kotlin/com/toasttab/gradle/testkit/TestKitWithCustomLocatorIntegrationTest.kt
+++ b/junit5/src/test/kotlin/com/toasttab/gradle/testkit/TestKitWithCustomLocatorIntegrationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Toast Inc.
+ * Copyright (c) 2025 Toast Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,16 @@
 
 package com.toasttab.gradle.testkit
 
-import org.gradle.api.provider.MapProperty
-import org.gradle.api.provider.Property
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.contains
 
-abstract class TestkitExtension {
-    abstract val testProjectsDir: Property<String>
-    abstract val replaceTokens: MapProperty<String, String>
-
-    fun replaceToken(name: String, value: String) {
-        replaceTokens.put(name, value)
+@TestKit(locator = FullyQualifiedNameProjectLocator::class)
+class TestKitWithCustomLocatorIntegrationTest {
+    @Test
+    fun `basic project`(project: TestProject) {
+        expectThat(
+            project.build("dependencies").output
+        ).contains("compileClasspath")
     }
 }

--- a/junit5/src/test/projects/com/toasttab/gradle/testkit/TestKitWithCustomLocatorIntegrationTest/basic project/build.gradle.kts
+++ b/junit5/src/test/projects/com/toasttab/gradle/testkit/TestKitWithCustomLocatorIntegrationTest/basic project/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    java
+}

--- a/junit5/src/test/projects/com/toasttab/gradle/testkit/TestKitWithCustomLocatorIntegrationTest/basic project/settings.gradle.kts
+++ b/junit5/src/test/projects/com/toasttab/gradle/testkit/TestKitWithCustomLocatorIntegrationTest/basic project/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "test"

--- a/testkit-plugin/src/main/kotlin/com/toasttab/gradle/testkit/TestkitPlugin.kt
+++ b/testkit-plugin/src/main/kotlin/com/toasttab/gradle/testkit/TestkitPlugin.kt
@@ -41,17 +41,20 @@ class TestkitPlugin @Inject constructor(
         val testProjectDir = project.layout.buildDirectory.dir("test-projects")
 
         project.tasks.register<Copy>("copyTestProjects") {
-            from(extension.testProjectsDir)
+            from(extension.testProjectsDir.getOrElse("src/test/projects"))
             into(testProjectDir)
 
+            val tokens = mapOf(
+                "TESTKIT_PLUGIN_VERSION" to BuildConfig.VERSION,
+                "TESTKIT_INTEGRATION_REPO" to project.integrationDirectory().path,
+                "VERSION" to "${project.version}"
+            ) + extension.replaceTokens.get()
+
+            // default up-to-date checks ignore the tokens
+            inputs.property("tokens", tokens)
+
             filter<ReplaceTokens>(
-                mapOf(
-                    "tokens" to mapOf(
-                        "TESTKIT_PLUGIN_VERSION" to BuildConfig.VERSION,
-                        "TESTKIT_INTEGRATION_REPO" to project.integrationDirectory().path,
-                        "VERSION" to "${project.version}"
-                    ) + extension.replaceTokens
-                )
+                mapOf("tokens" to tokens)
             )
         }
 


### PR DESCRIPTION
* Update the readme
* Provide an alternative implementation of the project locator
* Use Gradle `Property` concept in the plugin extension
* Fix (?) up-to-date checks for the copy task