### PR TITLE
Remove an unnecessary warning log

### DIFF
--- a/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/IntegrationPublishing.kt
+++ b/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/IntegrationPublishing.kt
@@ -168,10 +168,10 @@ private fun Project.configureIntegrationPublishingForDependency(project: Project
         val extension = project.extensions.findByType<GradlePluginDevelopmentExtension>()
 
         if (extension == null) {
-            logger.warn("No GradlePluginDevelopmentExtension found for project ${project.path}")
+            logger.debug("${project.path} is not a plugin project")
         } else {
             if (extension.plugins.isEmpty()) {
-                logger.warn("No plugins are declared in project ${project.path}")
+                logger.warn("${project.path} is a plugin project without any plugins defined")
             } else {
                 for (plugin in extension.plugins) {
                     dependsOn("${project.path}:${plugin.publishTask(repo)}")

--- a/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/IntegrationPublishing.kt
+++ b/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/IntegrationPublishing.kt
@@ -168,10 +168,10 @@ private fun Project.configureIntegrationPublishingForDependency(project: Project
         val extension = project.extensions.findByType<GradlePluginDevelopmentExtension>()
 
         if (extension == null) {
-            logger.debug("${project.path} is not a plugin project")
+            logger.debug("{} is not a plugin project", project.path)
         } else {
             if (extension.plugins.isEmpty()) {
-                logger.warn("${project.path} is a plugin project without any plugins defined")
+                logger.warn("{} is a plugin project without any plugins defined", project.path)
             } else {
                 for (plugin in extension.plugins) {
                     dependsOn("${project.path}:${plugin.publishTask(repo)}")


### PR DESCRIPTION
This change adjusts logging to not issue a warning on every subproject that is not a plugin project