### PR TITLE
Replace unmaintained semantic-build-versioning with Reckon

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,17 +1,17 @@
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
-buildscript {
-    repositories {
-        gradlePluginPortal()
-    }
-    dependencies {
-        classpath("gradle.plugin.net.vivin:gradle-semantic-build-versioning:4.0.0")
-    }
+plugins {
+    id("org.ajoberstar.reckon.settings") version "2.0.0"
+}
+
+extensions.configure<org.ajoberstar.reckon.gradle.ReckonExtension> {
+    setDefaultInferredScope("patch")
+    snapshots()
+    setScopeCalc(calcScopeFromProp())
+    setStageCalc(calcStageFromProp())
 }
 
 rootProject.name = "testkit-plugins"
-
-apply(plugin = "net.vivin.gradle-semantic-build-versioning")
 
 include(
     ":jacoco-reflect", ":junit5", ":testkit-plugin", ":coverage-plugin", ":integration-tests"


### PR DESCRIPTION
## Summary
- `gradle-semantic-build-versioning` is no longer maintained and will break on upcoming Gradle versions. Replace it with `org.ajoberstar.reckon.settings` 2.0.0 (actively maintained, Gradle 9 compatible, requires Java 17 — already satisfied by CI's corretto 17).
- Preserves existing version semantics: dev builds resolve to `X.Y.Z-SNAPSHOT`, tag pushes resolve to a clean `X.Y.Z`. `isRelease()` in `buildSrc/src/main/kotlin/Common.kt` continues to key off the `-SNAPSHOT` suffix without changes.
- Releasing is unchanged from the CI operator's perspective: push a tag, the release workflow runs. Reckon picks up the tag as the version automatically — no property flags needed.
- Dropped the empty `semantic-build-versioning.gradle` config file.

Unlike the equivalent change in `expediter`, no subproject-version reset is needed here: every subproject applies `publishing-conventions`, which already assigns `version = rootProject.version`, so Reckon's per-project version propagation has no visible effect on jar filenames.

## Test plan
- [ ] CI green on this PR
- [ ] `./gradlew properties` shows `version: X.Y.Z-SNAPSHOT` on a non-tag commit
- [ ] On next tag push, release workflow publishes a clean `X.Y.Z` artifact (no `-SNAPSHOT`)

Generated with [Claude Code](https://claude.com/claude-code)