### PR TITLE
Fix InstrumentWithJacocoOfflineTask plugin validation under Gradle 9.5

### DIFF
--- a/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/InstrumentWithJacocoOfflineTask.kt
+++ b/shared-build-logic/src/main/kotlin/com/toasttab/gradle/testkit/shared/InstrumentWithJacocoOfflineTask.kt
@@ -19,6 +19,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputDirectory
@@ -29,11 +30,13 @@ import org.gradle.workers.WorkerExecutor
 import java.io.FileOutputStream
 import javax.inject.Inject
 
+@CacheableTask
 abstract class InstrumentWithJacocoOfflineTask : DefaultTask() {
     @get:Classpath
     abstract val classpath: ConfigurableFileCollection
 
     @get:InputFile
+    @get:Classpath
     abstract val jar: RegularFileProperty
 
     @get:OutputDirectory


### PR DESCRIPTION
## Summary
- Gradle 9.5.0 (adopted in 6461e35) tightened plugin validation: task classes must declare caching behavior, and file inputs must declare a normalization strategy. `:testkit-plugin:validatePlugins` started failing on `main` with two errors on `InstrumentWithJacocoOfflineTask`.
- Annotated the task with `@CacheableTask` (jar instrumentation is deterministic given its inputs) and marked the `jar` input with `@Classpath`, matching the existing `classpath` normalization.

## Test plan
- [x] `./gradlew :testkit-plugin:validatePlugins` passes locally
- [ ] CI `Build` job succeeds on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)