### PR TITLE
Restore newlines in PGP_KEY env var

### DIFF
--- a/buildSrc/src/main/kotlin/Common.kt
+++ b/buildSrc/src/main/kotlin/Common.kt
@@ -22,7 +22,7 @@ val Project.libs get() = the<org.gradle.accessors.dm.LibrariesForLibs>()
 
 object Pgp {
     val key by lazy {
-        System.getenv("PGP_KEY")
+        System.getenv("PGP_KEY")?.replace('$', '\n')
     }
 
     val password by lazy {


### PR DESCRIPTION
## Summary
- Port over the `PGP_KEY` transformation already in use in `expediter`: GitHub Actions secrets cannot store raw newlines, so the PGP signing key is stored with newlines escaped as `$`. Unescape at read time in `Pgp.key` so `useInMemoryPgpKeys` gets a valid armored key during release signing.
- No other Maven Central publishing drift between this repo and `expediter` — the `ossrh-staging-api.central.sonatype.com` endpoint and `nexus` 2.0.0 bump (1ea3579) are already here, and expediter's `-Preckon.stage=final` drop doesn't apply (this repo's Reckon port never added that flag).

## Test plan
- [ ] Next tag push runs the release workflow and signed artifacts reach the central staging repo (previously would fail at signing if the secret contains `$`-escaped newlines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)