### PR TITLE
Pass -Preckon.stage=final when publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         distribution: corretto
         java-version: 17
     - name: Publish
-      run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository publishPlugins --stacktrace --no-daemon
+      run: ./gradlew -Preckon.stage=final publishToSonatype closeAndReleaseSonatypeStagingRepository publishPlugins --stacktrace --no-daemon
       env:
         PGP_KEY: ${{ secrets.PGP_KEY }}
         PGP_PASSWORD: ${{ secrets.PGP_PASSWORD }}


### PR DESCRIPTION
## Root cause

The 0.0.17 release workflow failed with `Task 'publishToSonatype' not found in root project 'testkit-plugins' and its subprojects.` The failed run log shows `Reckoned version: 0.0.18-SNAPSHOT` — Reckon resolved a SNAPSHOT on the tag-push build, not `0.0.17`.

The chain from there:
- `isRelease()` keys off the `-SNAPSHOT` suffix → returns `false`
- `nexus-staging-conventions.gradle.kts` wraps `nexusPublishing { sonatype { ... } }` in `if (isRelease())`, so the `sonatype` NexusRepository is never created
- `io.github.gradle-nexus.publish-plugin` only registers `publishTo<RepoName>` tasks for the repositories that exist (see `NexusPublishPlugin.kt:233`), so without `sonatype`, no `publishToSonatype` task gets registered
- Gradle's name-based task selector can't find `publishToSonatype` anywhere in the build → the error we see

## Reproduction

Locally at the 0.0.17 commit, simulating what Reckon does with no stage flag:

```
$ ./gradlew -Preckon.stage=snapshot publishToSonatype --dry-run
Reckoned version: 0.0.18-SNAPSHOT
...
* What went wrong:
Task 'publishToSonatype' not found in root project 'testkit-plugins' and its subprojects.
```

Exact same error. With `-Preckon.stage=final` the version resolves to `0.0.17`, `isRelease()` is true, and the task exists.

## Why the flag ended up missing

The initial Reckon migration in `expediter` (commit `14ffce9`) added `-Preckon.stage=final` to the release workflow. A follow-up (`e0fcecd`, "Drop redundant -Preckon.stage=final") removed it, arguing Reckon infers the version from the tag automatically. `testkit-plugins` picked up the post-drop form in commit `0336c30`. But expediter's claim was never validated by a post-Reckon tag push — its last release tag (0.2.0) predates its Reckon migration. The 0.0.17 release here is the first real tag-push test of the Reckon setup in either repo, and it shows the flag is in fact required.

## Test plan

- [ ] After merge, delete and re-push `0.0.17` (or cut `0.0.18`) and confirm the release workflow publishes to Sonatype

🤖 Generated with [Claude Code](https://claude.com/claude-code)