### PR TITLE
Fix release workflow: ignore .kotlin and set reckon.stage=final

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         distribution: corretto
         java-version: 17
     - name: Publish
-      run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository publishPlugins --stacktrace --no-daemon
+      run: ./gradlew -Preckon.stage=final publishToSonatype closeAndReleaseSonatypeStagingRepository publishPlugins --stacktrace --no-daemon
       env:
         PGP_KEY: ${{ secrets.PGP_KEY }}
         PGP_PASSWORD: ${{ secrets.PGP_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ local.properties
 build
 out
 .gradle
+.kotlin
 .idea
 *.iml
 


### PR DESCRIPTION
## Root cause

The 0.0.17 release failed with `Task 'publishToSonatype' not found in root project 'testkit-plugins' and its subprojects`. The failed run resolved `Reckoned version: 0.0.18-SNAPSHOT` rather than `0.0.17`, which made `isRelease()` false, the `if (isRelease()) { nexusPublishing { sonatype { ... } } }` block skip, and the `publishToSonatype` task never get registered.

The chain from release-tag-push to SNAPSHOT version:

1. `buildSrc/build.gradle.kts` adds `../shared-build-logic/src/main/kotlin` as a Kotlin source dir. No equivalent in expediter.
2. This forces the Kotlin compiler to run against that external source tree during the settings phase. It writes `buildSrc/.kotlin/sessions/kotlin-compiler-<id>.salive` as a daemon liveness file.
3. `.kotlin` was not ignored. JGit's `status()` reports the tree as dirty with `untracked=[buildSrc/.kotlin/sessions/kotlin-compiler-...salive]`.
4. Reckon's `GitInventorySupplier.isClean()` returns `false` (confirmed via `--debug`: `Git repository is not clean: ... untracked=[buildSrc/.kotlin/sessions/kotlin-compiler-...salive]`).
5. In `Reckoner.reckonTargetVersion` (reckon-core-2.0.0), the "rebuild" branch requires all three of `isClean() && currentVersion.isPresent() && stage == null`. With `clean=false`, that branch is skipped, falling through to the snapshot path — output `0.0.18-SNAPSHOT`.
6. `isRelease()` checks for `-SNAPSHOT` suffix → false → no `sonatype {}` configured → no `publishToSonatype` task registered → `TaskSelectionException`.

## Fix (defense in depth)

1. **Add `.kotlin` to `.gitignore`** — removes the untracked session file from Reckon's view so the clean check passes naturally. Also quiets `git status` during local development.
2. **Pass `-Preckon.stage=final` in the release workflow** — short-circuits the clean check entirely. The final-stage branch (`Reckoner.reckonTargetVersion`, reckon-core-2.0.0) returns the target normal before ever reaching the rebuild branch. Defensive against any future tool dropping a new untracked cache dir into the tree during the settings phase.

## Reproduction

Locally, fresh clone at the `0.0.17` tag (matching actions/checkout's `git init`, full fetch, `checkout --force refs/tags/0.0.17`):

```
$ ./gradlew properties 2>&1 | grep -E '^version:|Reckoned'
Reckoned version: 0.0.18-SNAPSHOT
version: 0.0.18-SNAPSHOT

$ ./gradlew properties --debug 2>&1 | grep 'not clean'
Git repository is not clean: added=[], changed=[], removed=[], untracked=[buildSrc/.kotlin/sessions/kotlin-compiler-*.salive], modified=[], missing=[]
```

With `.kotlin` ignored (committed + tag moved to that commit):

```
$ ./gradlew properties 2>&1 | grep -E '^version:|Reckoned'
Reckoned version: 0.0.17
version: 0.0.17
```

## Why expediter isn't affected

Expediter's `buildSrc/build.gradle.kts` doesn't add external Kotlin source dirs, so the Kotlin compiler never creates `buildSrc/.kotlin/` during settings evaluation. Same Reckon config, same gitignore, but no untracked file to trip Reckon's clean check. Expediter's `-Preckon.stage=final` drop in `e0fcecd` with the claim it's redundant actually does hold for expediter — just not here.

## Test plan

- [ ] After merge, delete and re-push `0.0.17` (or cut `0.0.18`) and confirm the release workflow publishes to Sonatype

🤖 Generated with [Claude Code](https://claude.com/claude-code)