### PR TITLE
Use shared JaCoCo version in integration-tests

### DIFF
--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -23,7 +23,7 @@ gradlePlugin {
 }
 
 jacoco {
-    toolVersion = "0.8.12"
+    toolVersion = libs.versions.jacoco.get()
 }
 
 tasks {


### PR DESCRIPTION
## Summary
- `integration-tests/build.gradle.kts` hard-coded `jacoco.toolVersion = \"0.8.12\"`, shadowing the 0.8.14 version in `libs.versions.toml`.
- On Java 25, 0.8.12 fails instrumentation with `Unsupported class file major version 69`.
- Switched to `libs.versions.jacoco.get()` so the catalog is the single source of truth.

## Test plan
- [ ] CI green on Java 17
- [ ] Manual verification: `./gradlew build` on Java 25 no longer hits the JaCoCo class-version error

🤖 Generated with [Claude Code](https://claude.com/claude-code)