### PR TITLE
Drop -Preckon.stage=final from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         distribution: corretto
         java-version: 17
     - name: Publish
-      run: ./gradlew -Preckon.stage=final publishToSonatype closeAndReleaseSonatypeStagingRepository publishPlugins --stacktrace --no-daemon
+      run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository publishPlugins --stacktrace --no-daemon
       env:
         PGP_KEY: ${{ secrets.PGP_KEY }}
         PGP_PASSWORD: ${{ secrets.PGP_PASSWORD }}


### PR DESCRIPTION
## Summary
- Tagging `0.1.0` published as `0.1.1` to Maven Central because the release workflow passed `-Preckon.stage=final`.
- With `stage` set, reckon skips the rebuild branch in `Reckoner.reckonTargetVersion` that would return the tag's exact version when `isClean() && currentVersion.isPresent() && stage == null`, and instead computes a target normal via `defaultInferredScope=patch` — bumping `0.1.0` to `0.1.1`.
- The `.kotlin` → `.gitignore` change from #46 is the real fix for the untracked-file clean-check problem; the `-Preckon.stage=final` "defense in depth" is counterproductive.

## Verification
At tag `0.1.0` with a clean tree:

```
$ ./gradlew properties 2>&1 | grep -E '^version:|Reckoned'
Reckoned version: 0.1.0
version: 0.1.0
```

With `-Preckon.stage=final` (the bug):

```
$ ./gradlew properties -Preckon.stage=final 2>&1 | grep -E '^version:|Reckoned'
Reckoned version: 0.1.1
version: 0.1.1
```

## Test plan
- [ ] After merge, re-push `0.1.0` (or cut a new tag) and confirm the release workflow publishes the tagged version, not tag+1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)