### PR TITLE
Attach per-version properties to parameterized Gradle versions

### DIFF
--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/GradleVersion.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/GradleVersion.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Toast Inc.
+ * Copyright (c) 2026 Toast Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,11 @@
 
 package com.toasttab.gradle.testkit
 
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.ArgumentsSource
-
-@ArgumentsSource(TestProjectExtension::class)
-@ParameterizedTest
-annotation class ParameterizedWithGradleVersions(
-    val value: Array<String> = [],
-    val versions: Array<GradleVersion> = []
+@Retention(AnnotationRetention.RUNTIME)
+annotation class GradleVersion(
+    val version: String,
+    val properties: Array<Property> = []
 )
+
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Property(val key: String, val value: String)

--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/GradleVersionArgument.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/GradleVersionArgument.kt
@@ -16,12 +16,23 @@
 package com.toasttab.gradle.testkit
 
 class GradleVersionArgument private constructor(
-    val version: String?
+    val version: String?,
+    val properties: Map<String, String> = emptyMap()
 ) {
-    override fun toString() = version ?: "default"
+    fun property(key: String): String? = properties[key]
+
+    override fun toString() = when {
+        version == null -> "default"
+        properties.isEmpty() -> version
+        else -> "$version${properties.entries.joinToString(prefix = " [", postfix = "]") { "${it.key}=${it.value}" }}"
+    }
 
     companion object {
-        fun of(version: String) = GradleVersionArgument(version)
+        fun of(version: String, properties: Map<String, String> = emptyMap()) =
+            GradleVersionArgument(version, properties)
+
+        fun of(spec: GradleVersion) =
+            GradleVersionArgument(spec.version, spec.properties.associate { it.key to it.value })
 
         val DEFAULT = GradleVersionArgument(null)
     }

--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestKit.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestKit.kt
@@ -26,5 +26,6 @@ import kotlin.reflect.KClass
 annotation class TestKit(
     val locator: KClass<out ProjectLocator> = SimpleNameProjectLocator::class,
     val gradleVersions: Array<String> = [],
+    val versions: Array<GradleVersion> = [],
     val cleanup: Boolean = true
 )

--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProject.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProject.kt
@@ -31,7 +31,6 @@ class TestProject(
 ) {
     fun property(key: String): String? = gradleVersion.property(key)
 
-
     companion object {
         private val LOGGER = LoggerFactory.getLogger(TestProject::class.java)
     }

--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProject.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProject.kt
@@ -25,10 +25,13 @@ import kotlin.io.path.deleteRecursively
 
 class TestProject(
     val dir: Path,
-    private val gradleVersion: GradleVersionArgument,
+    val gradleVersion: GradleVersionArgument,
     private val cleanup: Boolean,
     private val initArgs: List<String> = emptyList()
 ) {
+    fun property(key: String): String? = gradleVersion.property(key)
+
+
     companion object {
         private val LOGGER = LoggerFactory.getLogger(TestProject::class.java)
     }

--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProjectExtension.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProjectExtension.kt
@@ -42,9 +42,10 @@ private const val LOCATOR = "locator"
 private const val PROJECTS = "PROJECTS"
 
 data class ProjectKey(
-    val gradleVersion: String?
+    val gradleVersion: String?,
+    val properties: Map<String, String> = emptyMap()
 ) {
-    constructor(gradleVersion: GradleVersionArgument) : this(gradleVersion.version)
+    constructor(gradleVersion: GradleVersionArgument) : this(gradleVersion.version, gradleVersion.properties)
 }
 
 class TestProjects : CloseableResource {
@@ -87,16 +88,16 @@ class TestProjectExtension : ParameterResolver, BeforeAllCallback, AfterTestExec
 
     override fun provideArguments(context: ExtensionContext): Stream<out Arguments> {
         val methodAnn = context.requiredTestMethod.getAnnotation(ParameterizedWithGradleVersions::class.java)
+        val classAnn = context.requiredTestClass.getAnnotation(TestKit::class.java)
 
-        val versions = if (methodAnn.value.isNotEmpty()) {
-            methodAnn.value
-        } else {
-            context.requiredTestClass.getAnnotation(TestKit::class.java).gradleVersions
+        val specs: List<GradleVersionArgument> = when {
+            methodAnn.versions.isNotEmpty() -> methodAnn.versions.map(GradleVersionArgument::of)
+            methodAnn.value.isNotEmpty() -> methodAnn.value.map { GradleVersionArgument.of(it) }
+            classAnn.versions.isNotEmpty() -> classAnn.versions.map(GradleVersionArgument::of)
+            else -> classAnn.gradleVersions.map { GradleVersionArgument.of(it) }
         }
 
-        return versions.map {
-            Arguments.of(context.project(GradleVersionArgument.of(it)))
-        }.stream()
+        return specs.map { Arguments.of(context.project(it)) }.stream()
     }
 
     companion object {

--- a/junit5/src/test/kotlin/com/toasttab/gradle/testkit/GradleVersionPropertiesIntegrationTest.kt
+++ b/junit5/src/test/kotlin/com/toasttab/gradle/testkit/GradleVersionPropertiesIntegrationTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.gradle.testkit
+
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+
+@TestKit(
+    versions = [
+        GradleVersion(
+            version = "8.6",
+            properties = [Property(key = "kotlin", value = "1.9.24")]
+        ),
+        GradleVersion(
+            version = "8.7",
+            properties = [Property(key = "kotlin", value = "2.0.0")]
+        )
+    ]
+)
+class GradleVersionPropertiesIntegrationTest {
+    @ParameterizedWithGradleVersions
+    fun `per-version properties are attached to the test project`(project: TestProject) {
+        val expectedKotlin = when (project.gradleVersion.version) {
+            "8.6" -> "1.9.24"
+            "8.7" -> "2.0.0"
+            else -> error("unexpected gradle version ${project.gradleVersion.version}")
+        }
+
+        expectThat(project.property("kotlin")).isEqualTo(expectedKotlin)
+    }
+}

--- a/junit5/src/test/projects/GradleVersionPropertiesIntegrationTest/per-version properties are attached to the test project/build.gradle.kts
+++ b/junit5/src/test/projects/GradleVersionPropertiesIntegrationTest/per-version properties are attached to the test project/build.gradle.kts
@@ -1,0 +1,5 @@
+plugins {
+    java
+}
+
+println("gradle version = ${gradle.gradleVersion}")

--- a/junit5/src/test/projects/GradleVersionPropertiesIntegrationTest/per-version properties are attached to the test project/settings.gradle.kts
+++ b/junit5/src/test/projects/GradleVersionPropertiesIntegrationTest/per-version properties are attached to the test project/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "test"


### PR DESCRIPTION
## Summary

- Adds a `@GradleVersion(version, properties = [@Property(key, value)])` sub-annotation so each Gradle version in a parameterized test can carry extra metadata (e.g. a matching Kotlin version to pair with an older Gradle).
- Both `@TestKit` and `@ParameterizedWithGradleVersions` gain a `versions: Array<GradleVersion>` field alongside the existing `Array<String>` form. Resolution priority: method `versions` → method `value` → class `versions` → class `gradleVersions`. Fully backward compatible.
- `GradleVersionArgument` carries the properties; `ProjectKey` includes them so the per-version `TestProject` cache stays correct.
- `TestProject.property(key)` exposes the metadata to test bodies.
- Display names include the properties, e.g. `project(gradle: 8.6 [kotlin=1.9.24])`.

### Example

```kotlin
@TestKit(versions = [
    GradleVersion(version = "8.6", properties = [Property(key = "kotlin", value = "1.9.24")]),
    GradleVersion(version = "8.7", properties = [Property(key = "kotlin", value = "2.0.0")])
])
class MyTest {
    @ParameterizedWithGradleVersions
    fun test(project: TestProject) {
        val kotlin = project.property("kotlin")
        // use `kotlin` to template the build file, pick a plugin version, etc.
    }
}
```

## Test plan

- [ ] New `GradleVersionPropertiesIntegrationTest` exercises the feature and passes
- [ ] Existing `TestKitIntegrationTest` still uses the legacy `gradleVersions = [...]` form unchanged
- [ ] Confirm display names render properties: `project(gradle: 8.6 [kotlin=1.9.24])`
- [ ] CI green across the `:junit5` module

🤖 Generated with [Claude Code](https://claude.com/claude-code)