### PR TITLE
Bump spotless to 8.4.0 and ktlint to 1.8.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,4 @@
 [*.kt]
 ktlint_standard_trailing-comma-on-call-site = disabled
 ktlint_standard_trailing-comma-on-declaration-site = disabled
+ktlint_function_naming_ignore_when_annotated_with = Test, ParameterizedWithGradleVersions

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -11,7 +11,7 @@ repositories {
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     compilerOptions {
-        jvmTarget = JvmTarget.JVM_11
+        jvmTarget = JvmTarget.JVM_17
     }
 }
 
@@ -24,8 +24,8 @@ sourceSets {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 dependencies {

--- a/coverage-plugin/src/main/kotlin/com/toasttab/gradle/testkit/FlushJacocoPlugin.kt
+++ b/coverage-plugin/src/main/kotlin/com/toasttab/gradle/testkit/FlushJacocoPlugin.kt
@@ -23,13 +23,15 @@ import org.gradle.api.flow.FlowParameters
 import org.gradle.api.flow.FlowScope
 import javax.inject.Inject
 
-class FlushJacocoPlugin @Inject constructor(
-    private val flowScope: FlowScope
-) : Plugin<Project> {
-    override fun apply(target: Project) {
-        flowScope.always(DumpAction::class.java) { }
+class FlushJacocoPlugin
+    @Inject
+    constructor(
+        private val flowScope: FlowScope
+    ) : Plugin<Project> {
+        override fun apply(target: Project) {
+            flowScope.always(DumpAction::class.java) { }
+        }
     }
-}
 
 class DumpAction : FlowAction<FlowParameters.None> {
     override fun execute(parameters: FlowParameters.None) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,8 @@
 kotlin = "2.3.21"
 
 nexus = "2.0.0"
-ktlint = "0.50.0"
-spotless = "6.21.0"
+ktlint = "1.8.0"
+spotless = "8.4.0"
 
 jacoco = "0.8.14"
 

--- a/integration-tests/src/test/kotlin/com/toasttab/gradle/testkit/FlushJacocoPluginIntegrationTest.kt
+++ b/integration-tests/src/test/kotlin/com/toasttab/gradle/testkit/FlushJacocoPluginIntegrationTest.kt
@@ -48,12 +48,13 @@ class FlushJacocoPluginIntegrationTest {
                 """.trimIndent()
             )
 
-            TestProjectExtension.createProject(
-                projectDir = projectDir,
-                gradleVersion = GradleVersionArgument.of("8.7"),
-                cleanup = true,
-                coverageRecorder = recorder
-            ).build("build", "--configuration-cache", "--stacktrace")
+            TestProjectExtension
+                .createProject(
+                    projectDir = projectDir,
+                    gradleVersion = GradleVersionArgument.of("8.7"),
+                    cleanup = true,
+                    coverageRecorder = recorder
+                ).build("build", "--configuration-cache", "--stacktrace")
         }
 
         recorder.close()
@@ -61,15 +62,16 @@ class FlushJacocoPluginIntegrationTest {
         val classes = hashSetOf<String>()
 
         file.inputStream().buffered().use {
-            ExecutionDataReader(it).apply {
-                setExecutionDataVisitor { data ->
-                    if (data.name.startsWith("com/toasttab")) {
-                        classes.add(data.name)
+            ExecutionDataReader(it)
+                .apply {
+                    setExecutionDataVisitor { data ->
+                        if (data.name.startsWith("com/toasttab")) {
+                            classes.add(data.name)
+                        }
                     }
-                }
 
-                setSessionInfoVisitor { }
-            }.read()
+                    setSessionInfoVisitor { }
+                }.read()
         }
 
         expectThat(classes).contains(

--- a/jacoco-reflect/src/main/kotlin/com/toasttab/gradle/testkit/jacoco/JacocoRt.kt
+++ b/jacoco-reflect/src/main/kotlin/com/toasttab/gradle/testkit/jacoco/JacocoRt.kt
@@ -30,7 +30,10 @@ private class ReflectiveJacocoAgent(
 ) : JacocoAgent {
     private val options by lazy {
         // agent.options
-        agent.javaClass.getDeclaredField("options").apply { isAccessible = true }.get(agent)
+        agent.javaClass
+            .getDeclaredField("options")
+            .apply { isAccessible = true }
+            .get(agent)
     }
 
     override val location: String
@@ -53,11 +56,12 @@ object JacocoRt {
 
     private val agentLookup by lazy {
         runCatching {
-            val rt = try {
-                ClassLoader.getSystemClassLoader().loadClass(RT_CLASS)
-            } catch (e: ClassNotFoundException) {
-                JacocoRt::class.java.classLoader.loadClass(RT_CLASS)
-            }
+            val rt =
+                try {
+                    ClassLoader.getSystemClassLoader().loadClass(RT_CLASS)
+                } catch (e: ClassNotFoundException) {
+                    JacocoRt::class.java.classLoader.loadClass(RT_CLASS)
+                }
 
             ReflectiveJacocoAgent(rt.getMethod("getAgent").invoke(null))
         }

--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/CoverageRecorder.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/CoverageRecorder.kt
@@ -33,34 +33,35 @@ private class ReaderTask(
     private val readingSession = AtomicBoolean(false)
     private val running = AtomicBoolean(true)
 
-    private val reader = object : RemoteControlReader(sock.getInputStream()) {
-        init {
-            setSessionInfoVisitor { s ->
-                readingSession.set(true)
-            }
+    private val reader =
+        object : RemoteControlReader(sock.getInputStream()) {
+            init {
+                setSessionInfoVisitor { s ->
+                    readingSession.set(true)
+                }
 
-            setExecutionDataVisitor { ex ->
-                synchronized(writer) {
-                    writer.visitClassExecution(ex)
+                setExecutionDataVisitor { ex ->
+                    synchronized(writer) {
+                        writer.visitClassExecution(ex)
+                    }
                 }
             }
-        }
 
-        override fun readBlock(blockid: Byte): Boolean {
-            if (blockid == 32.toByte()) {
-                // OK message which follows jacoco tcpclient dumping execution data
-                finishSession()
+            override fun readBlock(blockid: Byte): Boolean {
+                if (blockid == 32.toByte()) {
+                    // OK message which follows jacoco tcpclient dumping execution data
+                    finishSession()
+                }
+                return super.readBlock(blockid)
             }
-            return super.readBlock(blockid)
-        }
 
-        override fun read() =
-            try {
-                super.read()
-            } catch (e: Exception) {
-                false
-            }
-    }
+            override fun read() =
+                try {
+                    super.read()
+                } catch (e: Exception) {
+                    false
+                }
+        }
 
     init {
         start()
@@ -103,21 +104,23 @@ class CoverageRecorder(
 
     private val tasks = mutableListOf<ReaderTask>()
 
-    private val runner = thread {
-        while (!server.isClosed) {
-            val sock = try {
-                server.accept()
-            } catch (e: Exception) {
-                break
+    private val runner =
+        thread {
+            while (!server.isClosed) {
+                val sock =
+                    try {
+                        server.accept()
+                    } catch (e: Exception) {
+                        break
+                    }
+
+                tasks.add(ReaderTask(sock, writer))
             }
 
-            tasks.add(ReaderTask(sock, writer))
+            for (task in tasks) {
+                task.done()
+            }
         }
-
-        for (task in tasks) {
-            task.done()
-        }
-    }
 
     val port: Int get() = server.localPort
 

--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/GradleVersion.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/GradleVersion.kt
@@ -22,4 +22,7 @@ annotation class GradleVersion(
 )
 
 @Retention(AnnotationRetention.RUNTIME)
-annotation class Property(val key: String, val value: String)
+annotation class Property(
+    val key: String,
+    val value: String
+)

--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/GradleVersionArgument.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/GradleVersionArgument.kt
@@ -21,18 +21,20 @@ class GradleVersionArgument private constructor(
 ) {
     fun property(key: String): String? = properties[key]
 
-    override fun toString() = when {
-        version == null -> "default"
-        properties.isEmpty() -> version
-        else -> "$version${properties.entries.joinToString(prefix = " [", postfix = "]") { "${it.key}=${it.value}" }}"
-    }
+    override fun toString() =
+        when {
+            version == null -> "default"
+            properties.isEmpty() -> version
+            else -> "$version${properties.entries.joinToString(prefix = " [", postfix = "]") { "${it.key}=${it.value}" }}"
+        }
 
     companion object {
-        fun of(version: String, properties: Map<String, String> = emptyMap()) =
-            GradleVersionArgument(version, properties)
+        fun of(
+            version: String,
+            properties: Map<String, String> = emptyMap()
+        ) = GradleVersionArgument(version, properties)
 
-        fun of(spec: GradleVersion) =
-            GradleVersionArgument(spec.version, spec.properties.associate { it.key to it.value })
+        fun of(spec: GradleVersion) = GradleVersionArgument(spec.version, spec.properties.associate { it.key to it.value })
 
         val DEFAULT = GradleVersionArgument(null)
     }

--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/ProjectLocator.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/ProjectLocator.kt
@@ -20,15 +20,22 @@ import java.nio.file.Path
 import kotlin.io.path.Path
 
 interface ProjectLocator {
-    fun projectPath(root: String, context: ExtensionContext): Path
+    fun projectPath(
+        root: String,
+        context: ExtensionContext
+    ): Path
 }
 
 class SimpleNameProjectLocator : ProjectLocator {
-    override fun projectPath(root: String, context: ExtensionContext) =
-        Path(root, context.requiredTestClass.simpleName, context.requiredTestMethod.name)
+    override fun projectPath(
+        root: String,
+        context: ExtensionContext
+    ) = Path(root, context.requiredTestClass.simpleName, context.requiredTestMethod.name)
 }
 
 class FullyQualifiedNameProjectLocator : ProjectLocator {
-    override fun projectPath(root: String, context: ExtensionContext) =
-        Path(root, context.requiredTestClass.name.replace('.', '/'), context.requiredTestMethod.name)
+    override fun projectPath(
+        root: String,
+        context: ExtensionContext
+    ) = Path(root, context.requiredTestClass.name.replace('.', '/'), context.requiredTestMethod.name)
 }

--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestKitDisplayNameGenerator.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestKitDisplayNameGenerator.kt
@@ -19,10 +19,14 @@ import org.junit.jupiter.api.DisplayNameGenerator.Standard
 import java.lang.reflect.Method
 
 class TestKitDisplayNameGenerator : Standard() {
-    override fun generateDisplayNameForMethod(cls: Class<*>, method: Method) =
-        method.name + method.parameterTypes.filter {
-            it != TestProject::class.java
-        }.joinToString(", ", prefix = "(", postfix = ")") {
-            it.simpleName
-        }
+    override fun generateDisplayNameForMethod(
+        cls: Class<*>,
+        method: Method
+    ) = method.name +
+        method.parameterTypes
+            .filter {
+                it != TestProject::class.java
+            }.joinToString(", ", prefix = "(", postfix = ")") {
+                it.simpleName
+            }
 }

--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProject.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProject.kt
@@ -51,15 +51,17 @@ class TestProject(
 
     private fun createRunner(vararg args: String) = createRunner().withArguments(initArgs + args)
 
-    private fun createRunner() = GradleRunner.create()
-        .withProjectDir(dir.toFile())
-        .forwardStdOutput(output)
-        .forwardStdError(output).apply {
-            if (gradleVersion.version != null) {
-                withGradleVersion(gradleVersion.version)
-            }
-        }
-        .withArguments()
+    private fun createRunner() =
+        GradleRunner
+            .create()
+            .withProjectDir(dir.toFile())
+            .forwardStdOutput(output)
+            .forwardStdError(output)
+            .apply {
+                if (gradleVersion.version != null) {
+                    withGradleVersion(gradleVersion.version)
+                }
+            }.withArguments()
 
     fun logOutputOnce() {
         if (!outputLogged.getAndSet(true)) {

--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProjectExtension.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProjectExtension.kt
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.extension.ParameterResolver
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.ArgumentsProvider
 import java.nio.file.Path
-import java.util.*
+import java.util.Optional
 import java.util.concurrent.ConcurrentHashMap
 import java.util.stream.Stream
 import kotlin.io.path.ExperimentalPathApi
@@ -51,7 +51,10 @@ data class ProjectKey(
 class TestProjects : CloseableResource {
     private val projects = ConcurrentHashMap<ProjectKey, TestProject>()
 
-    fun project(key: ProjectKey, create: (ProjectKey) -> TestProject) = projects.computeIfAbsent(key, create)
+    fun project(
+        key: ProjectKey,
+        create: (ProjectKey) -> TestProject
+    ) = projects.computeIfAbsent(key, create)
 
     override fun close() {
         projects.values.forEach(TestProject::close)
@@ -62,7 +65,12 @@ class TestProjects : CloseableResource {
     }
 }
 
-class TestProjectExtension : ParameterResolver, BeforeAllCallback, AfterTestExecutionCallback, InvocationInterceptor, ArgumentsProvider {
+class TestProjectExtension :
+    ParameterResolver,
+    BeforeAllCallback,
+    AfterTestExecutionCallback,
+    InvocationInterceptor,
+    ArgumentsProvider {
     override fun beforeAll(context: ExtensionContext) {
         val coverage = CoverageSettings.settings
 
@@ -71,12 +79,17 @@ class TestProjectExtension : ParameterResolver, BeforeAllCallback, AfterTestExec
         }
     }
 
-    override fun supportsParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext) =
-        parameterContext.parameter.type == TestProject::class.java &&
-            extensionContext.parent.map { it::class.java.name } != Optional.of("org.junit.jupiter.engine.descriptor.TestTemplateExtensionContext")
+    override fun supportsParameter(
+        parameterContext: ParameterContext,
+        extensionContext: ExtensionContext
+    ) = parameterContext.parameter.type == TestProject::class.java &&
+        extensionContext.parent.map { it::class.java.name } !=
+        Optional.of("org.junit.jupiter.engine.descriptor.TestTemplateExtensionContext")
 
-    override fun resolveParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext) =
-        extensionContext.project(GradleVersionArgument.DEFAULT)
+    override fun resolveParameter(
+        parameterContext: ParameterContext,
+        extensionContext: ExtensionContext
+    ) = extensionContext.project(GradleVersionArgument.DEFAULT)
 
     override fun afterTestExecution(context: ExtensionContext) {
         context.executionException.ifPresent {
@@ -90,98 +103,114 @@ class TestProjectExtension : ParameterResolver, BeforeAllCallback, AfterTestExec
         val methodAnn = context.requiredTestMethod.getAnnotation(ParameterizedWithGradleVersions::class.java)
         val classAnn = context.requiredTestClass.getAnnotation(TestKit::class.java)
 
-        val specs: List<GradleVersionArgument> = when {
-            methodAnn.versions.isNotEmpty() -> methodAnn.versions.map(GradleVersionArgument::of)
-            methodAnn.value.isNotEmpty() -> methodAnn.value.map { GradleVersionArgument.of(it) }
-            classAnn.versions.isNotEmpty() -> classAnn.versions.map(GradleVersionArgument::of)
-            else -> classAnn.gradleVersions.map { GradleVersionArgument.of(it) }
-        }
+        val specs: List<GradleVersionArgument> =
+            when {
+                methodAnn.versions.isNotEmpty() -> methodAnn.versions.map(GradleVersionArgument::of)
+                methodAnn.value.isNotEmpty() -> methodAnn.value.map { GradleVersionArgument.of(it) }
+                classAnn.versions.isNotEmpty() -> classAnn.versions.map(GradleVersionArgument::of)
+                else -> classAnn.gradleVersions.map { GradleVersionArgument.of(it) }
+            }
 
         return specs.map { Arguments.of(context.project(it)) }.stream()
     }
 
     companion object {
-        private inline fun <reified T> ExtensionContext.get(namespace: ExtensionContext.Namespace, key: String) =
-            getStore(namespace).get(key, T::class.java)
+        private inline fun <reified T> ExtensionContext.get(
+            namespace: ExtensionContext.Namespace,
+            key: String
+        ) = getStore(namespace).get(key, T::class.java)
 
-        private inline fun <K, reified V> ExtensionContext.Store.cache(key: K, noinline f: (K) -> V) =
-            getOrComputeIfAbsent(key, f, V::class.java)
+        private inline fun <K, reified V> ExtensionContext.Store.cache(
+            key: K,
+            noinline f: (K) -> V
+        ) = getOrComputeIfAbsent(key, f, V::class.java)
 
         @OptIn(ExperimentalPathApi::class)
         private fun ExtensionContext.project(gradleVersion: GradleVersionArgument): TestProject {
             val parameters = requiredTestClass.getAnnotation(TestKit::class.java) ?: TestKit()
 
-            val locator = getStore(NAMESPACE).cache(LOCATOR) {
-                parameters.locator.java.getDeclaredConstructor().newInstance() as ProjectLocator
-            }
-
-            return getStore(NAMESPACE).cache(PROJECTS) {
-                TestProjects()
-            }.project(ProjectKey(gradleVersion)) {
-                val tempProjectDir = createTempDirectory("junit-gradlekit")
-
-                val location = locator.projectPath(System.getProperty("testkit-projects"), this)
-
-                if (!location.exists()) {
-                    error { "expected a test project in $location" }
+            val locator =
+                getStore(NAMESPACE).cache(LOCATOR) {
+                    parameters.locator.java
+                        .getDeclaredConstructor()
+                        .newInstance() as ProjectLocator
                 }
 
-                location.copyToRecursively(target = tempProjectDir, followLinks = false, overwrite = false)
+            return getStore(NAMESPACE)
+                .cache(PROJECTS) {
+                    TestProjects()
+                }.project(ProjectKey(gradleVersion)) {
+                    val tempProjectDir = createTempDirectory("junit-gradlekit")
 
-                createProject(
-                    tempProjectDir,
-                    gradleVersion,
-                    parameters.cleanup,
-                    CoverageSettings.settings?.let { get(NAMESPACE, COVERAGE_RECORDER) }
-                )
-            }
+                    val location = locator.projectPath(System.getProperty("testkit-projects"), this)
+
+                    if (!location.exists()) {
+                        error { "expected a test project in $location" }
+                    }
+
+                    location.copyToRecursively(target = tempProjectDir, followLinks = false, overwrite = false)
+
+                    createProject(
+                        tempProjectDir,
+                        gradleVersion,
+                        parameters.cleanup,
+                        CoverageSettings.settings?.let { get(NAMESPACE, COVERAGE_RECORDER) }
+                    )
+                }
         }
 
-        fun createProject(projectDir: Path, gradleVersion: GradleVersionArgument, cleanup: Boolean = true, coverageRecorder: CoverageRecorder?): TestProject {
+        fun createProject(
+            projectDir: Path,
+            gradleVersion: GradleVersionArgument,
+            cleanup: Boolean = true,
+            coverageRecorder: CoverageRecorder?
+        ): TestProject {
             val integrationRepo = System.getProperty("testkit-integration-repo")
             val projectVersion = System.getProperty("testkit-project-version")
             val pluginVersion = System.getProperty("testkit-plugin-version")
-            val plugins = System.getProperty("testkit-plugin-ids")?.split(',')?.joinToString(separator = "\n") {
-                """id("$it") version("$projectVersion")"""
-            } ?: ""
+            val plugins =
+                System.getProperty("testkit-plugin-ids")?.split(',')?.joinToString(separator = "\n") {
+                    """id("$it") version("$projectVersion")"""
+                } ?: ""
 
-            val initArgs = if (integrationRepo != null) {
-                projectDir.appendToFile(
-                    "init.gradle.kts",
-                    """
-    
-                    settingsEvaluated {
-                        pluginManagement {
-                            repositories {
-                                maven(url = "file://$integrationRepo")
-                                gradlePluginPortal()
-                            }
-                            
-                            plugins {
-                                id("com.toasttab.testkit.coverage") version("$pluginVersion")
-                                $plugins
+            val initArgs =
+                if (integrationRepo != null) {
+                    projectDir.appendToFile(
+                        "init.gradle.kts",
+                        """
+                        
+                        settingsEvaluated {
+                            pluginManagement {
+                                repositories {
+                                    maven(url = "file://$integrationRepo")
+                                    gradlePluginPortal()
+                                }
+                                
+                                plugins {
+                                    id("com.toasttab.testkit.coverage") version("$pluginVersion")
+                                    $plugins
+                                }
                             }
                         }
-                    }
-                    """.trimIndent()
-                )
+                        """.trimIndent()
+                    )
 
-                listOf("--init-script", "init.gradle.kts")
-            } else {
-                emptyList()
-            }
+                    listOf("--init-script", "init.gradle.kts")
+                } else {
+                    emptyList()
+                }
 
             if (coverageRecorder != null) {
                 projectDir.appendToFile(
                     "gradle.properties",
                     """
-                            
-                            # custom jacoco properties
-                            systemProp.jacoco-agent.output=tcpclient
-                            systemProp.jacoco-agent.port=${coverageRecorder.port}
-                            systemProp.jacoco-agent.sessionid=test
-                            systemProp.jacoco-agent.includes=${coverageRecorder.settings.includes}
-                            systemProp.jacoco-agent.excludes=${coverageRecorder.settings.excludes}
+                    
+                    # custom jacoco properties
+                    systemProp.jacoco-agent.output=tcpclient
+                    systemProp.jacoco-agent.port=${coverageRecorder.port}
+                    systemProp.jacoco-agent.sessionid=test
+                    systemProp.jacoco-agent.includes=${coverageRecorder.settings.includes}
+                    systemProp.jacoco-agent.excludes=${coverageRecorder.settings.excludes}
                     """.trimIndent()
                 )
             }
@@ -191,7 +220,10 @@ class TestProjectExtension : ParameterResolver, BeforeAllCallback, AfterTestExec
     }
 }
 
-private fun Path.appendToFile(fileName: String, text: String) {
+private fun Path.appendToFile(
+    fileName: String,
+    text: String
+) {
     val file = resolve(fileName)
 
     if (!file.exists()) {

--- a/junit5/src/test/kotlin/com/toasttab/gradle/testkit/GradleVersionPropertiesIntegrationTest.kt
+++ b/junit5/src/test/kotlin/com/toasttab/gradle/testkit/GradleVersionPropertiesIntegrationTest.kt
@@ -33,11 +33,12 @@ import strikt.assertions.isEqualTo
 class GradleVersionPropertiesIntegrationTest {
     @ParameterizedWithGradleVersions
     fun `per-version properties are attached to the test project`(project: TestProject) {
-        val expectedKotlin = when (project.gradleVersion.version) {
-            "8.6" -> "1.9.24"
-            "8.7" -> "2.0.0"
-            else -> error("unexpected gradle version ${project.gradleVersion.version}")
-        }
+        val expectedKotlin =
+            when (project.gradleVersion.version) {
+                "8.6" -> "1.9.24"
+                "8.7" -> "2.0.0"
+                else -> error("unexpected gradle version ${project.gradleVersion.version}")
+            }
 
         expectThat(project.property("kotlin")).isEqualTo(expectedKotlin)
     }

--- a/testkit-plugin/src/main/kotlin/com/toasttab/gradle/testkit/TestkitExtension.kt
+++ b/testkit-plugin/src/main/kotlin/com/toasttab/gradle/testkit/TestkitExtension.kt
@@ -22,7 +22,10 @@ abstract class TestkitExtension {
     abstract val testProjectsDir: Property<String>
     abstract val replaceTokens: MapProperty<String, String>
 
-    fun replaceToken(name: String, value: String) {
+    fun replaceToken(
+        name: String,
+        value: String
+    ) {
         replaceTokens.put(name, value)
     }
 }

--- a/testkit-plugin/src/main/kotlin/com/toasttab/gradle/testkit/TestkitPlugin.kt
+++ b/testkit-plugin/src/main/kotlin/com/toasttab/gradle/testkit/TestkitPlugin.kt
@@ -32,69 +32,74 @@ import org.gradle.kotlin.dsl.register
 import org.gradle.testing.jacoco.tasks.JacocoReportBase
 import javax.inject.Inject
 
-class TestkitPlugin @Inject constructor(
-    private val fs: FileSystemOperations
-) : Plugin<Project> {
-    override fun apply(project: Project) {
-        val extension = project.extensions.create<TestkitExtension>("testkitTests")
-        val destfile = project.layout.buildDirectory.file("jacoco/testkit.exec")
-        val testProjectDir = project.layout.buildDirectory.dir("test-projects")
+class TestkitPlugin
+    @Inject
+    constructor(
+        private val fs: FileSystemOperations
+    ) : Plugin<Project> {
+        override fun apply(project: Project) {
+            val extension = project.extensions.create<TestkitExtension>("testkitTests")
+            val destfile = project.layout.buildDirectory.file("jacoco/testkit.exec")
+            val testProjectDir = project.layout.buildDirectory.dir("test-projects")
 
-        project.tasks.register<Copy>("copyTestProjects") {
-            from(extension.testProjectsDir.getOrElse("src/test/projects"))
-            into(testProjectDir)
+            project.tasks.register<Copy>("copyTestProjects") {
+                from(extension.testProjectsDir.getOrElse("src/test/projects"))
+                into(testProjectDir)
 
-            val tokens = mapOf(
-                "TESTKIT_PLUGIN_VERSION" to BuildConfig.VERSION,
-                "TESTKIT_INTEGRATION_REPO" to project.integrationDirectory().path,
-                "VERSION" to "${project.version}"
-            ) + extension.replaceTokens.get()
+                val tokens =
+                    mapOf(
+                        "TESTKIT_PLUGIN_VERSION" to BuildConfig.VERSION,
+                        "TESTKIT_INTEGRATION_REPO" to project.integrationDirectory().path,
+                        "VERSION" to "${project.version}"
+                    ) + extension.replaceTokens.get()
 
-            // default up-to-date checks ignore the tokens
-            inputs.property("tokens", tokens)
+                // default up-to-date checks ignore the tokens
+                inputs.property("tokens", tokens)
 
-            filter<ReplaceTokens>(
-                mapOf("tokens" to tokens)
-            )
-        }
-
-        project.tasks.named<Test>("test") {
-            dependsOn("copyTestProjects")
-
-            doFirst(JacocoOutputCleanupTestTaskAction(fs, destfile))
-
-            inputs.dir(testProjectDir).withPropertyName("testkit-projects-input")
-                .withPathSensitivity(PathSensitivity.RELATIVE)
-
-            // declare an additional jacoco output file so that the JUnit JVM and the TestKit JVM
-            // do not try to write to the same file
-            outputs.file(destfile).withPropertyName("testkit-coverage-output")
-
-            systemProperty("testkit-coverage-output", "${destfile.get()}")
-            systemProperty("testkit-projects", "${testProjectDir.get()}")
-            systemProperty("testkit-integration-repo", project.integrationDirectory().path)
-            systemProperty("testkit-plugin-version", BuildConfig.VERSION)
-        }
-
-        project.configureIntegrationPublishing()
-
-        project.pluginManager.withPlugin("jacoco") {
-            project.pluginManager.withPlugin("jvm-test-suite") {
-                // add the TestKit jacoco file to outgoing artifacts so that it can be aggregated
-                project.configurations.getAt("coverageDataElementsForTest").outgoing.artifact(destfile) {
-                    type = ArtifactTypeDefinition.BINARY_DATA_TYPE
-                    builtBy("test")
-                }
+                filter<ReplaceTokens>(
+                    mapOf("tokens" to tokens)
+                )
             }
 
-            project.tasks.named<JacocoReportBase>("jacocoTestReport") {
-                // add the TestKit jacoco file to the local jacoco report
-                executionData.from(
-                    project.layout.buildDirectory.dir("jacoco").map {
-                        it.files("test.exec", "testkit.exec")
+            project.tasks.named<Test>("test") {
+                dependsOn("copyTestProjects")
+
+                doFirst(JacocoOutputCleanupTestTaskAction(fs, destfile))
+
+                inputs
+                    .dir(testProjectDir)
+                    .withPropertyName("testkit-projects-input")
+                    .withPathSensitivity(PathSensitivity.RELATIVE)
+
+                // declare an additional jacoco output file so that the JUnit JVM and the TestKit JVM
+                // do not try to write to the same file
+                outputs.file(destfile).withPropertyName("testkit-coverage-output")
+
+                systemProperty("testkit-coverage-output", "${destfile.get()}")
+                systemProperty("testkit-projects", "${testProjectDir.get()}")
+                systemProperty("testkit-integration-repo", project.integrationDirectory().path)
+                systemProperty("testkit-plugin-version", BuildConfig.VERSION)
+            }
+
+            project.configureIntegrationPublishing()
+
+            project.pluginManager.withPlugin("jacoco") {
+                project.pluginManager.withPlugin("jvm-test-suite") {
+                    // add the TestKit jacoco file to outgoing artifacts so that it can be aggregated
+                    project.configurations.getAt("coverageDataElementsForTest").outgoing.artifact(destfile) {
+                        type = ArtifactTypeDefinition.BINARY_DATA_TYPE
+                        builtBy("test")
                     }
-                )
+                }
+
+                project.tasks.named<JacocoReportBase>("jacocoTestReport") {
+                    // add the TestKit jacoco file to the local jacoco report
+                    executionData.from(
+                        project.layout.buildDirectory.dir("jacoco").map {
+                            it.files("test.exec", "testkit.exec")
+                        }
+                    )
+                }
             }
         }
     }
-}

--- a/testkit-plugin/src/test/kotlin/com/toasttab/gradle/testkit/TestkitPluginIntegrationTest.kt
+++ b/testkit-plugin/src/test/kotlin/com/toasttab/gradle/testkit/TestkitPluginIntegrationTest.kt
@@ -36,7 +36,8 @@ class TestkitPluginIntegrationTest {
 
         val projectDir = dir.resolve("TestkitPluginIntegrationTest/filtering")
 
-        GradleRunner.create()
+        GradleRunner
+            .create()
             .withProjectDir(projectDir.toFile())
             .withPluginClasspath()
             .withArguments("test")


### PR DESCRIPTION
## Summary
- Bump `spotless-plugin-gradle` 6.21.0 → 8.4.0 and `ktlint` 0.50.0 → 1.8.0
- Raise `buildSrc` to Java 17 (required by Spotless 8's classpath); consumer plugin artifacts continue to target Java 11
- Accommodate stricter ktlint defaults: replace a wildcard import, configure `ktlint_function_naming_ignore_when_annotated_with` for the custom `ParameterizedWithGradleVersions` test annotation
- Run `spotlessApply` across the codebase

## Test plan
- [x] `./gradlew spotlessApply` — clean
- [x] `./gradlew build` — compiles; produced `.class` files are major version 55 (Java 11)
- [x] Pre-existing `FlushJacocoPluginIntegrationTest` failure also reproduces on `main` without these changes, so it is unrelated

Generated with [Claude Code](https://claude.com/claude-code)