### PR TITLE
Write the testkit init script outside the test project dir

### DIFF
--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProjectExtension.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProjectExtension.kt
@@ -30,11 +30,14 @@ import java.util.Optional
 import java.util.concurrent.ConcurrentHashMap
 import java.util.stream.Stream
 import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.absolutePathString
 import kotlin.io.path.appendText
 import kotlin.io.path.copyToRecursively
 import kotlin.io.path.createFile
 import kotlin.io.path.createTempDirectory
+import kotlin.io.path.createTempFile
 import kotlin.io.path.exists
+import kotlin.io.path.writeText
 
 private val NAMESPACE = ExtensionContext.Namespace.create(TestProjectExtension::class.java.name, "testkit-project")
 private const val COVERAGE_RECORDER = "coverage-recorder"
@@ -176,17 +179,17 @@ class TestProjectExtension :
 
             val initArgs =
                 if (integrationRepo != null) {
-                    projectDir.appendToFile(
-                        "init.gradle.kts",
+                    // Write outside projectDir so the test project's lint/format tools don't see it.
+                    val initScript = createTempFile("testkit-init-", ".gradle.kts")
+                    initScript.writeText(
                         """
-                        
                         settingsEvaluated {
                             pluginManagement {
                                 repositories {
                                     maven(url = "file://$integrationRepo")
                                     gradlePluginPortal()
                                 }
-                                
+
                                 plugins {
                                     id("com.toasttab.testkit.coverage") version("$pluginVersion")
                                     $plugins
@@ -196,7 +199,7 @@ class TestProjectExtension :
                         """.trimIndent()
                     )
 
-                    listOf("--init-script", "init.gradle.kts")
+                    listOf("--init-script", initScript.absolutePathString())
                 } else {
                     emptyList()
                 }


### PR DESCRIPTION
The init script is currently written to `<projectDir>/init.gradle.kts`, which puts it inside any Kotlin lint/format scope the project under test configures (e.g. spotless's `*.kts` globs). Lines like `id(...) version("...")` for plugins with long version strings can exceed common max-line-length rules, causing Spotless to fail.

This PR writes the init script to a sibling temp file outside `projectDir` and passes its absolute path to `--init-script`. The daemon doesn't care where the file lives, and the project's lint/format tools no longer see it.