### PR TITLE
Add property matrix support to @TestKit and @ParameterizedWithGradleVersions

### DIFF
--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/GradleVersion.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/GradleVersion.kt
@@ -26,3 +26,20 @@ annotation class Property(
     val key: String,
     val value: String
 )
+
+/**
+ * One axis of a property matrix. The cartesian product of all axes on a [TestKit] or
+ * [ParameterizedWithGradleVersions] is expanded into one test cell per combination.
+ */
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Axis(
+    val key: String,
+    val values: Array<String>
+)
+
+internal fun cartesianProduct(axes: Array<Axis>): List<Map<String, String>> =
+    axes.fold(listOf(emptyMap())) { acc, axis ->
+        acc.flatMap { combo ->
+            axis.values.map { value -> combo + (axis.key to value) }
+        }
+    }

--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/GradleVersionArgument.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/GradleVersionArgument.kt
@@ -21,12 +21,14 @@ class GradleVersionArgument private constructor(
 ) {
     fun property(key: String): String? = properties[key]
 
-    override fun toString() =
-        when {
-            version == null -> "default"
-            properties.isEmpty() -> version
-            else -> "$version${properties.entries.joinToString(prefix = " [", postfix = "]") { "${it.key}=${it.value}" }}"
+    override fun toString(): String {
+        val versionPart = version ?: "default"
+        return if (properties.isEmpty()) {
+            versionPart
+        } else {
+            "$versionPart${properties.entries.joinToString(prefix = " [", postfix = "]") { "${it.key}=${it.value}" }}"
         }
+    }
 
     companion object {
         fun of(
@@ -35,6 +37,14 @@ class GradleVersionArgument private constructor(
         ) = GradleVersionArgument(version, properties)
 
         fun of(spec: GradleVersion) = GradleVersionArgument(spec.version, spec.properties.associate { it.key to it.value })
+
+        /**
+         * Produce a new argument with [overrides] merged onto [base]'s properties (overrides win).
+         */
+        fun of(
+            base: GradleVersionArgument,
+            overrides: Map<String, String>
+        ) = GradleVersionArgument(base.version, base.properties + overrides)
 
         val DEFAULT = GradleVersionArgument(null)
     }

--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/ParameterizedWithGradleVersions.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/ParameterizedWithGradleVersions.kt
@@ -23,5 +23,6 @@ import org.junit.jupiter.params.provider.ArgumentsSource
 annotation class ParameterizedWithGradleVersions(
     @Deprecated("Use versions instead.", ReplaceWith("versions"))
     val value: Array<String> = [],
-    val versions: Array<GradleVersion> = []
+    val versions: Array<GradleVersion> = [],
+    val matrix: Array<Axis> = []
 )

--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestKit.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestKit.kt
@@ -28,5 +28,6 @@ annotation class TestKit(
     @Deprecated("Use versions instead.", ReplaceWith("versions"))
     val gradleVersions: Array<String> = [],
     val versions: Array<GradleVersion> = [],
+    val matrix: Array<Axis> = [],
     val cleanup: Boolean = true
 )

--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProjectExtension.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProjectExtension.kt
@@ -30,11 +30,14 @@ import java.util.Optional
 import java.util.concurrent.ConcurrentHashMap
 import java.util.stream.Stream
 import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.absolutePathString
 import kotlin.io.path.appendText
 import kotlin.io.path.copyToRecursively
 import kotlin.io.path.createFile
 import kotlin.io.path.createTempDirectory
+import kotlin.io.path.createTempFile
 import kotlin.io.path.exists
+import kotlin.io.path.writeText
 
 private val NAMESPACE = ExtensionContext.Namespace.create(TestProjectExtension::class.java.name, "testkit-project")
 private const val COVERAGE_RECORDER = "coverage-recorder"
@@ -176,17 +179,17 @@ class TestProjectExtension :
 
             val initArgs =
                 if (integrationRepo != null) {
-                    projectDir.appendToFile(
-                        "init.gradle.kts",
+                    // Write outside projectDir so the test project's lint/format tools don't see it.
+                    val initScript = createTempFile("testkit-init-", ".gradle.kts")
+                    initScript.writeText(
                         """
-                        
                         settingsEvaluated {
                             pluginManagement {
                                 repositories {
                                     maven(url = "file://$integrationRepo")
                                     gradlePluginPortal()
                                 }
-                                
+
                                 plugins {
                                     id("com.toasttab.testkit.coverage") version("$pluginVersion")
                                     $plugins
@@ -196,7 +199,7 @@ class TestProjectExtension :
                         """.trimIndent()
                     )
 
-                    listOf("--init-script", "init.gradle.kts")
+                    listOf("--init-script", initScript.absolutePathString())
                 } else {
                     emptyList()
                 }

--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProjectExtension.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProjectExtension.kt
@@ -107,12 +107,27 @@ class TestProjectExtension :
         val methodAnn = context.requiredTestMethod.getAnnotation(ParameterizedWithGradleVersions::class.java)
         val classAnn = context.requiredTestClass.getAnnotation(TestKit::class.java)
 
-        val specs: List<GradleVersionArgument> =
+        val matrix = if (methodAnn.matrix.isNotEmpty()) methodAnn.matrix else classAnn.matrix
+
+        val baseSpecs: List<GradleVersionArgument> =
             when {
                 methodAnn.versions.isNotEmpty() -> methodAnn.versions.map(GradleVersionArgument::of)
                 methodAnn.value.isNotEmpty() -> methodAnn.value.map { GradleVersionArgument.of(it) }
                 classAnn.versions.isNotEmpty() -> classAnn.versions.map(GradleVersionArgument::of)
-                else -> classAnn.gradleVersions.map { GradleVersionArgument.of(it) }
+                classAnn.gradleVersions.isNotEmpty() -> classAnn.gradleVersions.map { GradleVersionArgument.of(it) }
+                matrix.isNotEmpty() -> listOf(GradleVersionArgument.DEFAULT)
+                else -> emptyList()
+            }
+
+        val specs =
+            if (matrix.isEmpty()) {
+                baseSpecs
+            } else {
+                baseSpecs.flatMap { base ->
+                    cartesianProduct(matrix).map { combo ->
+                        GradleVersionArgument.of(base, combo)
+                    }
+                }
             }
 
         return specs.map { Arguments.of(context.project(it)) }.stream()

--- a/junit5/src/test/kotlin/com/toasttab/gradle/testkit/PropertyMatrixIntegrationTest.kt
+++ b/junit5/src/test/kotlin/com/toasttab/gradle/testkit/PropertyMatrixIntegrationTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.gradle.testkit
+
+import org.junit.jupiter.api.AfterAll
+import strikt.api.expectThat
+import strikt.assertions.containsExactlyInAnyOrder
+import strikt.assertions.isContainedIn
+import strikt.assertions.isNotNull
+import java.util.concurrent.ConcurrentHashMap
+
+private val OBSERVED = ConcurrentHashMap.newKeySet<Pair<String, String>>()
+
+@TestKit(
+    matrix = [
+        Axis(key = "alpha", values = ["a1", "a2"]),
+        Axis(key = "beta", values = ["b1", "b2", "b3"])
+    ]
+)
+class PropertyMatrixIntegrationTest {
+    @ParameterizedWithGradleVersions
+    fun `cartesian product of axes is expanded into one cell per combination`(project: TestProject) {
+        val alpha = project.property("alpha")
+        val beta = project.property("beta")
+
+        expectThat(alpha).isNotNull().isContainedIn(setOf("a1", "a2"))
+        expectThat(beta).isNotNull().isContainedIn(setOf("b1", "b2", "b3"))
+
+        OBSERVED.add(alpha!! to beta!!)
+    }
+
+    companion object {
+        @JvmStatic
+        @AfterAll
+        fun assertAllCellsRan() {
+            expectThat(OBSERVED).containsExactlyInAnyOrder(
+                "a1" to "b1", "a1" to "b2", "a1" to "b3",
+                "a2" to "b1", "a2" to "b2", "a2" to "b3"
+            )
+        }
+    }
+}

--- a/junit5/src/test/projects/PropertyMatrixIntegrationTest/cartesian product of axes is expanded into one cell per combination/build.gradle.kts
+++ b/junit5/src/test/projects/PropertyMatrixIntegrationTest/cartesian product of axes is expanded into one cell per combination/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    java
+}

--- a/junit5/src/test/projects/PropertyMatrixIntegrationTest/cartesian product of axes is expanded into one cell per combination/settings.gradle.kts
+++ b/junit5/src/test/projects/PropertyMatrixIntegrationTest/cartesian product of axes is expanded into one cell per combination/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "test"


### PR DESCRIPTION
## Summary

Cartesian-product property expansion is a recurring need (e.g. 3 kotlin × 3 ktlint = 9 cells). Today every cell must be enumerated by hand as a `@GradleVersion(version = ..., properties = [...])` entry, because annotation arrays must be compile-time constants.

This PR introduces an `Axis(key, values)` annotation and a `matrix` field on both `@TestKit` and `@ParameterizedWithGradleVersions`. The provider expands the cartesian product of all axes, then for each combination emits one `GradleVersionArgument` per `versions` entry (or one `DEFAULT` argument if `versions` is empty), with combo properties merged onto the version's literal `@Property` entries (combo wins on conflict).

### Before

```kotlin
@TestKit(versions = [
    GradleVersion(\"8.7\", [Property(\"kotlin\", \"2.0.21\"), Property(\"ktlint\", \"1.5.0\")]),
    GradleVersion(\"8.7\", [Property(\"kotlin\", \"2.0.21\"), Property(\"ktlint\", \"1.7.1\")]),
    GradleVersion(\"8.7\", [Property(\"kotlin\", \"2.0.21\"), Property(\"ktlint\", \"1.8.0\")]),
    GradleVersion(\"8.7\", [Property(\"kotlin\", \"2.1.20\"), Property(\"ktlint\", \"1.5.0\")]),
    // ... 5 more lines ...
])
```

### After

```kotlin
@TestKit(
    versions = [GradleVersion(\"8.7\")],
    matrix = [
        Axis(\"kotlin\", [\"2.0.21\", \"2.1.20\", \"2.2.0\"]),
        Axis(\"ktlint\", [\"1.5.0\", \"1.7.1\", \"1.8.0\"])
    ]
)
```

Also fixes `GradleVersionArgument.toString()` to include properties in the display name even when the gradle version is the default (matrix-only tests previously showed up as `project(gradle: default)` with no axis info).

## Stacked on

[#56 (init-script-temp-dir)](https://github.com/open-toast/testkit-plugins/pull/56). Diff is reviewable independently.

## Test plan

- [x] `./gradlew test` passes (full suite, including the new `PropertyMatrixIntegrationTest`).