### PR TITLE
Inject TestProject into vanilla @ParameterizedTest methods

### DIFF
--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProjectExtension.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProjectExtension.kt
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.extension.ParameterResolver
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.ArgumentsProvider
 import java.nio.file.Path
-import java.util.Optional
 import java.util.concurrent.ConcurrentHashMap
 import java.util.stream.Stream
 import kotlin.io.path.ExperimentalPathApi
@@ -82,9 +81,19 @@ class TestProjectExtension :
     override fun supportsParameter(
         parameterContext: ParameterContext,
         extensionContext: ExtensionContext
-    ) = parameterContext.parameter.type == TestProject::class.java &&
-        extensionContext.parent.map { it::class.java.name } !=
-        Optional.of("org.junit.jupiter.engine.descriptor.TestTemplateExtensionContext")
+    ): Boolean {
+        if (parameterContext.parameter.type != TestProject::class.java) {
+            return false
+        }
+        // When the test method is driven by @ParameterizedWithGradleVersions, this extension
+        // *also* serves as the ArgumentsProvider — so the TestProject argument is supplied via
+        // provideArguments(). Bowing out here keeps us from competing with JUnit's
+        // ParameterizedTestParameterResolver and triggering a "multiple competing resolvers"
+        // error. Plain @ParameterizedTest methods (e.g. with @MethodSource) get a TestProject
+        // injected normally.
+        val method = extensionContext.requiredTestMethod
+        return !method.isAnnotationPresent(ParameterizedWithGradleVersions::class.java)
+    }
 
     override fun resolveParameter(
         parameterContext: ParameterContext,

--- a/junit5/src/test/kotlin/com/toasttab/gradle/testkit/MethodSourceInteropIntegrationTest.kt
+++ b/junit5/src/test/kotlin/com/toasttab/gradle/testkit/MethodSourceInteropIntegrationTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.gradle.testkit
+
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import strikt.api.expectThat
+import strikt.assertions.containsExactlyInAnyOrder
+import java.util.concurrent.ConcurrentHashMap
+
+private val OBSERVED = ConcurrentHashMap.newKeySet<Pair<String, String>>()
+
+/**
+ * Demonstrates that a [TestProject] can be injected into a regular `@ParameterizedTest` method
+ * driven by `@MethodSource`. JUnit's `ParameterizedTestParameterResolver` claims parameter slots
+ * left-to-right starting from index 0 for arguments-source values, so the extension-injected
+ * [TestProject] must be the last parameter.
+ */
+@TestKit
+class MethodSourceInteropIntegrationTest {
+    @ParameterizedTest
+    @MethodSource("matrix")
+    fun `TestProject is injected alongside MethodSource arguments`(
+        kotlin: String,
+        ktlint: String,
+        project: TestProject
+    ) {
+        OBSERVED.add(kotlin to ktlint)
+
+        // Sanity-check that the project is real and the cell is identified by the row args.
+        check(project.dir.toFile().exists()) { "expected real test project for $kotlin/$ktlint" }
+    }
+
+    companion object {
+        @JvmStatic
+        fun matrix(): List<Arguments> =
+            listOf("1.9.24", "2.0.0").flatMap { kotlin ->
+                listOf("1.5.0", "1.7.1").map { ktlint ->
+                    Arguments.of(kotlin, ktlint)
+                }
+            }
+
+        @JvmStatic
+        @AfterAll
+        fun assertAllRowsRan() {
+            expectThat(OBSERVED).containsExactlyInAnyOrder(
+                "1.9.24" to "1.5.0", "1.9.24" to "1.7.1",
+                "2.0.0" to "1.5.0", "2.0.0" to "1.7.1"
+            )
+        }
+    }
+}

--- a/junit5/src/test/kotlin/com/toasttab/gradle/testkit/MethodSourceInteropIntegrationTest.kt
+++ b/junit5/src/test/kotlin/com/toasttab/gradle/testkit/MethodSourceInteropIntegrationTest.kt
@@ -59,8 +59,10 @@ class MethodSourceInteropIntegrationTest {
         @AfterAll
         fun assertAllRowsRan() {
             expectThat(OBSERVED).containsExactlyInAnyOrder(
-                "1.9.24" to "1.5.0", "1.9.24" to "1.7.1",
-                "2.0.0" to "1.5.0", "2.0.0" to "1.7.1"
+                "1.9.24" to "1.5.0",
+                "1.9.24" to "1.7.1",
+                "2.0.0" to "1.5.0",
+                "2.0.0" to "1.7.1"
             )
         }
     }

--- a/junit5/src/test/projects/MethodSourceInteropIntegrationTest/TestProject is injected alongside MethodSource arguments/build.gradle.kts
+++ b/junit5/src/test/projects/MethodSourceInteropIntegrationTest/TestProject is injected alongside MethodSource arguments/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    java
+}

--- a/junit5/src/test/projects/MethodSourceInteropIntegrationTest/TestProject is injected alongside MethodSource arguments/settings.gradle.kts
+++ b/junit5/src/test/projects/MethodSourceInteropIntegrationTest/TestProject is injected alongside MethodSource arguments/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "test"


### PR DESCRIPTION
This PR enables mixing and matching the existing injection machinery for TestProject with other parameter injections.

The extension's parameter resolver bows out for any `TestTemplateExtensionContext`, which meant `@ParameterizedTest` methods (driven by `@MethodSource`, `@CsvSource`, junit-pioneer's `@CartesianTest`, etc.) couldn't take a `TestProject` argument. This avoids competing with `@ParameterizedWithGradleVersions`, where this extension serves both as the `ParameterResolver` and the `ArgumentsProvider`.

This PR tightens the guard: it only abstains when the test method actually carries `@ParameterizedWithGradleVersions`. Other parameterized tests now get a `TestProject` injected through the regular `resolveParameter` path.

```kotlin
@TestKit
class MyTest {
    @CartesianTest
    @CartesianTest.MethodFactory(\"axes\")
    fun foo(kotlin: String, ktlint: String, project: TestProject) {
        project.build(\"-PkotlinVersion=\$kotlin\", \"-PktlintVersion=\$ktlint\")
    }
}
```

### Calling convention

For position-driven argument sources (`@MethodSource`, `@CsvSource`, `@ValueSource`), JUnit's `ParameterizedTestParameterResolver` claims parameter slots `[0, argsLength)` regardless of which slots are intended for an extension. The extension-injected `TestProject` must therefore come *after* all source-provided parameters; otherwise JUnit reports \"multiple competing resolvers\" because both this extension and `ParameterizedTestParameterResolver` claim the same slot.

Annotation-aware sources like junit-pioneer's `@CartesianTest` claim parameters by annotation rather than position, so `TestProject` can sit anywhere in the signature.

The new integration test exercises the position-driven case.