### PR TITLE
Make plugin-management repositories in the init script configurable

### DIFF
--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProjectExtension.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProjectExtension.kt
@@ -177,7 +177,8 @@ class TestProjectExtension :
             val initArgs =
                 if (integrationRepo != null) {
                     val customRepos =
-                        System.getProperty("testkit-plugin-repositories")
+                        System
+                            .getProperty("testkit-plugin-repositories")
                             ?.takeIf { it.isNotEmpty() }
                             ?.split(',')
                             ?.joinToString(separator = "\n") { """maven(url = "$it")""" }

--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProjectExtension.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProjectExtension.kt
@@ -176,17 +176,24 @@ class TestProjectExtension :
 
             val initArgs =
                 if (integrationRepo != null) {
+                    val customRepos =
+                        System.getProperty("testkit-plugin-repositories")
+                            ?.takeIf { it.isNotEmpty() }
+                            ?.split(',')
+                            ?.joinToString(separator = "\n") { """maven(url = "$it")""" }
+                    val repositoryBlock = customRepos ?: "gradlePluginPortal()"
+
                     projectDir.appendToFile(
                         "init.gradle.kts",
                         """
-                        
+
                         settingsEvaluated {
                             pluginManagement {
                                 repositories {
                                     maven(url = "file://$integrationRepo")
-                                    gradlePluginPortal()
+                                    $repositoryBlock
                                 }
-                                
+
                                 plugins {
                                     id("com.toasttab.testkit.coverage") version("$pluginVersion")
                                     $plugins

--- a/testkit-plugin/src/main/kotlin/com/toasttab/gradle/testkit/TestkitExtension.kt
+++ b/testkit-plugin/src/main/kotlin/com/toasttab/gradle/testkit/TestkitExtension.kt
@@ -15,12 +15,22 @@
 
 package com.toasttab.gradle.testkit
 
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 
 abstract class TestkitExtension {
     abstract val testProjectsDir: Property<String>
     abstract val replaceTokens: MapProperty<String, String>
+
+    /**
+     * Maven repository URLs that the testkit init script should declare under
+     * `pluginManagement.repositories` for plugin resolution by the test project. If empty
+     * (the default), the init script falls back to `gradlePluginPortal()`. If non-empty, the
+     * listed URLs replace `gradlePluginPortal()` entirely — useful when your project resolves
+     * plugins from an internal mirror and shouldn't reach out to the public portal.
+     */
+    abstract val pluginRepositories: ListProperty<String>
 
     fun replaceToken(
         name: String,

--- a/testkit-plugin/src/main/kotlin/com/toasttab/gradle/testkit/TestkitExtension.kt
+++ b/testkit-plugin/src/main/kotlin/com/toasttab/gradle/testkit/TestkitExtension.kt
@@ -22,14 +22,6 @@ import org.gradle.api.provider.Property
 abstract class TestkitExtension {
     abstract val testProjectsDir: Property<String>
     abstract val replaceTokens: MapProperty<String, String>
-
-    /**
-     * Maven repository URLs that the testkit init script should declare under
-     * `pluginManagement.repositories` for plugin resolution by the test project. If empty
-     * (the default), the init script falls back to `gradlePluginPortal()`. If non-empty, the
-     * listed URLs replace `gradlePluginPortal()` entirely — useful when your project resolves
-     * plugins from an internal mirror and shouldn't reach out to the public portal.
-     */
     abstract val pluginRepositories: ListProperty<String>
 
     fun replaceToken(

--- a/testkit-plugin/src/main/kotlin/com/toasttab/gradle/testkit/TestkitPlugin.kt
+++ b/testkit-plugin/src/main/kotlin/com/toasttab/gradle/testkit/TestkitPlugin.kt
@@ -79,6 +79,11 @@ class TestkitPlugin
                 systemProperty("testkit-projects", "${testProjectDir.get()}")
                 systemProperty("testkit-integration-repo", project.integrationDirectory().path)
                 systemProperty("testkit-plugin-version", BuildConfig.VERSION)
+
+                val pluginRepos = extension.pluginRepositories.getOrElse(emptyList())
+                if (pluginRepos.isNotEmpty()) {
+                    systemProperty("testkit-plugin-repositories", pluginRepos.joinToString(separator = ","))
+                }
             }
 
             project.configureIntegrationPublishing()


### PR DESCRIPTION
## Summary

Today the testkit-injected init script always uses `gradlePluginPortal()` for plugins not in the on-disk integration repo. Projects can't opt out of hitting the public rate-limiting repos.

This PR adds `pluginRepositories` to `TestkitExtension`. When non-empty, the listed Maven URLs replace `gradlePluginPortal()` in the generated init script. When empty (the default), behavior is unchanged.

```kotlin
testkitTests {
    pluginRepositories.add("https://nexus.example.com/repository/gradle-plugins/")
}
```

Wired through as a new `testkit-plugin-repositories` system property on the `Test` task, consumed by `TestProjectExtension` when emitting the `pluginManagement.repositories` block.