### PR TITLE
Expose a withDebug toggle on TestProject

### DIFF
--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProject.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProject.kt
@@ -42,9 +42,10 @@ class TestProject(
      * (`GradleRunner.withDebug(true)`) so IDE breakpoints attach. Off by default; intended for
      * ad-hoc debugging. Returns `this` for chaining: `project.withDebug(true).build("check")`.
      */
-    fun withDebug(debug: Boolean) = apply {
-        this.debug = debug
-    }
+    fun withDebug(debug: Boolean) =
+        apply {
+            this.debug = debug
+        }
 
     private val output = StringWriter()
     private val outputLogged = AtomicBoolean()

--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProject.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProject.kt
@@ -35,6 +35,17 @@ class TestProject(
         private val LOGGER = LoggerFactory.getLogger(TestProject::class.java)
     }
 
+    private var debug: Boolean = false
+
+    /**
+     * Run subsequent [build] / [buildAndFail] calls in the test JVM
+     * (`GradleRunner.withDebug(true)`) so IDE breakpoints attach. Off by default; intended for
+     * ad-hoc debugging. Returns `this` for chaining: `project.withDebug(true).build("check")`.
+     */
+    fun withDebug(debug: Boolean) = apply {
+        this.debug = debug
+    }
+
     private val output = StringWriter()
     private val outputLogged = AtomicBoolean()
 
@@ -57,6 +68,7 @@ class TestProject(
             .withProjectDir(dir.toFile())
             .forwardStdOutput(output)
             .forwardStdError(output)
+            .withDebug(debug)
             .apply {
                 if (gradleVersion.version != null) {
                     withGradleVersion(gradleVersion.version)


### PR DESCRIPTION
`GradleRunner.withDebug(true)` runs the build in the test JVM so IDE breakpoints attach. 

This PR adds a fluent `withDebug(Boolean)` on `TestProject` that defers to `GradleRunner.withDebug(...)` when the underlying runner is constructed. Off by default; per-test scope.

```kotlin
@Test
fun foo(project: TestProject) {
    project.withDebug(true).build(\"printVersion\")
}
```