### PR TITLE
Revert: Make plugin-management repositories in the init script configurable (#59)

### DIFF
--- a/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProjectExtension.kt
+++ b/junit5/src/main/kotlin/com/toasttab/gradle/testkit/TestProjectExtension.kt
@@ -188,14 +188,6 @@ class TestProjectExtension :
 
             val initArgs =
                 if (integrationRepo != null) {
-                    val customRepos =
-                        System
-                            .getProperty("testkit-plugin-repositories")
-                            ?.takeIf { it.isNotEmpty() }
-                            ?.split(',')
-                            ?.joinToString(separator = "\n") { """maven(url = "$it")""" }
-                    val repositoryBlock = customRepos ?: "gradlePluginPortal()"
-
                     // Write outside projectDir so the test project's lint/format tools don't see it.
                     val initScript = createTempFile("testkit-init-", ".gradle.kts")
                     initScript.writeText(
@@ -204,7 +196,7 @@ class TestProjectExtension :
                             pluginManagement {
                                 repositories {
                                     maven(url = "file://$integrationRepo")
-                                    $repositoryBlock
+                                    gradlePluginPortal()
                                 }
 
                                 plugins {

--- a/testkit-plugin/src/main/kotlin/com/toasttab/gradle/testkit/TestkitExtension.kt
+++ b/testkit-plugin/src/main/kotlin/com/toasttab/gradle/testkit/TestkitExtension.kt
@@ -15,14 +15,12 @@
 
 package com.toasttab.gradle.testkit
 
-import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 
 abstract class TestkitExtension {
     abstract val testProjectsDir: Property<String>
     abstract val replaceTokens: MapProperty<String, String>
-    abstract val pluginRepositories: ListProperty<String>
 
     fun replaceToken(
         name: String,

--- a/testkit-plugin/src/main/kotlin/com/toasttab/gradle/testkit/TestkitPlugin.kt
+++ b/testkit-plugin/src/main/kotlin/com/toasttab/gradle/testkit/TestkitPlugin.kt
@@ -79,11 +79,6 @@ class TestkitPlugin
                 systemProperty("testkit-projects", "${testProjectDir.get()}")
                 systemProperty("testkit-integration-repo", project.integrationDirectory().path)
                 systemProperty("testkit-plugin-version", BuildConfig.VERSION)
-
-                val pluginRepos = extension.pluginRepositories.getOrElse(emptyList())
-                if (pluginRepos.isNotEmpty()) {
-                    systemProperty("testkit-plugin-repositories", pluginRepos.joinToString(separator = ","))
-                }
             }
 
             project.configureIntegrationPublishing()


### PR DESCRIPTION
Reverts #59.

`extension.pluginRepositories.getOrElse(emptyList())` is read inside the `tasks.named<Test>(\"test\") { ... }` configuration block. When the test task gets realized eagerly (e.g. by \`kotlin-dsl\` configuring its test source set during plugin application), the extension's `ListProperty` hasn't been mutated by the user's \`configure<TestkitExtension> { pluginRepositories.add(...) }\` block yet, so we read an empty list, never set the system property, and the init script falls back to `gradlePluginPortal()`.

Downstream configured `testkitTests.pluginRepositories` and the resulting init script still contained `gradlePluginPortal()` instead of the configured URL.

A correct implementation might defer the read to task execution time using `jvmArgumentProviders.add { ... }` or `Provider.map { ... }`.
